### PR TITLE
APPNG-2097 reworked LDAP implementation

### DIFF
--- a/appng-appngizer/src/test/resources/xml/site-property-list.xml
+++ b/appng-appngizer/src/test/resources/xml/site-property-list.xml
@@ -187,9 +187,9 @@
 		<description>The base-DN for LDAP-groups</description>
 	</property>
 	<property name="ldapHost" self="http://localhost/site/localhost/property/ldapHost">
-		<value>ldap:&lt;host&gt;:&lt;port&gt;</value>
-		<defaultValue>ldap:&lt;host&gt;:&lt;port&gt;</defaultValue>
-		<description>The LDAP host</description>
+		<value>ldap(s):&lt;host&gt;:&lt;port&gt;</value>
+		<defaultValue>ldap(s):&lt;host&gt;:&lt;port&gt;</defaultValue>
+		<description>The LDAP host in provider URL format ("ldap(s)://&lt;host&gt;:&lt;port&gt;"). Note that you might need to add CA certificates to the truststore of the executing JVM if you enable "ldaps://".</description>
 	</property>
 	<property name="ldapIdAttribute" self="http://localhost/site/localhost/property/ldapIdAttribute">
 		<value>sAMAccountName</value>
@@ -201,15 +201,25 @@
 		<defaultValue>secret</defaultValue>
 		<description>Password of the LDAP service-user</description>
 	</property>
+  <property name="ldapPrincipalScheme" self="http://localhost/site/localhost/property/ldapPrincipalScheme">
+    <value>SAM</value>
+    <defaultValue>SAM</defaultValue>
+    <description>How the LDAP principal is built from a given username when logging in. ["DN": results in "${site.ldapIdAttribute}=&gt;username&lt;,${site.ldapUserBaseDn}" - "UPN": results in "&gt;username&lt;@${site.ldapDomain}" - "SAM": results in "${site.ldapDomain}\\\\&gt;username&lt;"]. "UPN" and "SAM" are ActiveDirectory specific and "SAM" is the default to stay backward compatible.</description>
+  </property>
+  <property name="ldapStartTls" self="http://localhost/site/localhost/property/ldapStartTls">
+    <value>false</value>
+    <defaultValue>false</defaultValue>
+    <description>Use STARTTLS for the LDAP connection.</description>
+  </property>
 	<property name="ldapUser" self="http://localhost/site/localhost/property/ldapUser">
 		<value>serviceUser</value>
 		<defaultValue>serviceUser</defaultValue>
-		<description>The name of the LDAP service-user</description>
+		<description>The name of the LDAP service-user for general LDAP lookups. If the value is a Distinguished Name (e.g. "cn=Service User,dc=mycompany,dc=com") it will be used directly as LDAP principal. Otherwise the principal will be derived according to the value specified for ${site.ldapPrincipalScheme}.</description>
 	</property>
 	<property name="ldapUserBaseDn" self="http://localhost/site/localhost/property/ldapUserBaseDn">
 		<value>OU=Users,DC=example,DC=com</value>
 		<defaultValue>OU=Users,DC=example,DC=com</defaultValue>
-		<description>The base-DN for LDAP-users</description>
+		<description>The base-DN which is used to map a plain username to a Distinguished Name, if "DN" is used as principal scheme (see property "ldapPrincipalScheme").</description>
 	</property>
 	<property name="locale" self="http://localhost/site/localhost/property/locale">
 		<value>en</value>

--- a/appng-cli/src/test/java/org/appng/cli/commands/property/CommandListPropertiesTest.java
+++ b/appng-cli/src/test/java/org/appng/cli/commands/property/CommandListPropertiesTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
  */
 public class CommandListPropertiesTest extends AbstractCommandTest {
 
-	private static final int NUM_SITE_PROPERTIES = 59;
+	private static final int NUM_SITE_PROPERTIES = 61;
 	private static final int NUM_PLATFORM_PROPERTIES = 49;
 	private static final int PROP_ROOT_PATH_IDX = 32;
 	private ListProperties commandListProperties = new ListProperties();

--- a/appng-core/src/main/java/org/appng/core/service/CoreService.java
+++ b/appng-core/src/main/java/org/appng/core/service/CoreService.java
@@ -1703,8 +1703,7 @@ public class CoreService {
 			initializeSubject(subject);
 			subject.getApplicationroles(application);
 			if (UserType.GLOBAL_GROUP.equals(subject.getUserType())) {
-				List<SubjectImpl> membersOfGroup = ldapService.getMembersOfGroup(site.getProperties(),
-						subject.getAuthName());
+				List<SubjectImpl> membersOfGroup = ldapService.getMembersOfGroup(site, subject.getAuthName());
 				for (SubjectImpl ldapSubject : membersOfGroup) {
 					String timeZone = subject.getTimeZone();
 					if (null == timeZone) {

--- a/appng-core/src/main/java/org/appng/core/service/LdapService.java
+++ b/appng-core/src/main/java/org/appng/core/service/LdapService.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * 
  * @author Matthias Müller
+ * @author Dirk Heuvels
  */
 public class LdapService {
 	private static final Logger LOG = LoggerFactory.getLogger(LdapService.class);
@@ -212,11 +213,8 @@ public class LdapService {
 		try {
 			getContext(ldapCredentials);
 			return true;
-		} catch (IOException ioe) {
-			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ioe);
-			return false;
-		} catch (NamingException ne) {
-			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ne);
+		} catch (IOException | NamingException ex) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ex);
 			return false;
 		} finally {
 			closeContext();
@@ -281,10 +279,8 @@ public class LdapService {
 					}
 				}
 			}
-		} catch (IOException ioe) {
-			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ioe);
-		} catch (NamingException ne) {
-			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ne);
+		} catch (IOException | NamingException ex) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ex);
 		} finally {
 			closeContext();
 		}
@@ -327,10 +323,8 @@ public class LdapService {
 				ldapSubject.setEmail(email.toLowerCase());
 				subjects.add(ldapSubject);
 			}
-		} catch (IOException ioe) {
-			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ioe);
-		} catch (NamingException ne) {
-			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ne);
+		} catch (IOException | NamingException ex) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ex);
 		} finally {
 			closeContext();
 		}

--- a/appng-core/src/main/java/org/appng/core/service/LdapService.java
+++ b/appng-core/src/main/java/org/appng/core/service/LdapService.java
@@ -15,9 +15,13 @@
  */
 package org.appng.core.service;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.naming.AuthenticationException;
 import javax.naming.Context;
@@ -25,10 +29,13 @@ import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.StartTlsRequest;
+import javax.naming.ldap.StartTlsResponse;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 
-import org.apache.commons.lang3.StringUtils;
 import org.appng.api.model.Site;
 import org.appng.api.model.Subject;
 import org.appng.core.domain.SubjectImpl;
@@ -39,41 +46,144 @@ import org.slf4j.LoggerFactory;
  * Service providing methods to login {@link Subject}s based on the LDAP-configuration of a {@link Site}. The following
  * site-properties need to be configured properly:
  * <ul>
- * <li>{@value #LDAP_HOST}
  * <li>{@value #LDAP_DOMAIN}
- * <li>{@value #LDAP_USER}
- * <li>{@value #LDAP_PASSWORD}
  * <li>{@value #LDAP_GROUP_BASE_DN}
- * <li>{@value #LDAP_USER_BASE_DN}
+ * <li>{@value #LDAP_HOST}
  * <li>{@value #LDAP_ID_ATTRIBUTE}
+ * <li>{@value #LDAP_PASSWORD}
+ * <li>{@value #LDAP_PRINCIPAL_SCHEME}
+ * <li>{@value #LDAP_START_TLS}
+ * <li>{@value #LDAP_USER}
+ * <li>{@value #LDAP_USER_BASE_DN}
  * </ul>
  * 
  * @author Matthias Müller
  */
 public class LdapService {
-
 	private static final Logger LOG = LoggerFactory.getLogger(LdapService.class);
+
+	private String ldapCtxFactory = "com.sun.jndi.ldap.LdapCtxFactory";
+	private LdapContext ctx = null;
+	private StartTlsResponse tls = null;
 
 	private static final String CN_ATTRIBUTE = "cn";
 	private static final String MEMBER_ATTRIBUTE = "member";
 	private static final String MAIL_ATTRIBUTE = "mail";
 
+	private static final String SAM_DOMAIN_SEPARATOR = "\\";
+	private static final String LDAP_NETWORK_TIMEOUTS = "8000";
+
 	/** The domain for the LDAP authentication */
 	public static final String LDAP_DOMAIN = "ldapDomain";
-	/** Password of the LDAP service-user */
-	public static final String LDAP_PASSWORD = "ldapPassword";
-	/** The name of the LDAP service-user */
-	public static final String LDAP_USER = "ldapUser";
 	/** The base-DN for LDAP-groups */
 	public static final String LDAP_GROUP_BASE_DN = "ldapGroupBaseDn";
-	/** The base-DN for LDAP-users */
-	public static final String LDAP_USER_BASE_DN = "ldapUserBaseDn";
 	/** The LDAP host */
 	public static final String LDAP_HOST = "ldapHost";
 	/** The name of the LDAP-attribute containing the user-id used for authentication */
 	public static final String LDAP_ID_ATTRIBUTE = "ldapIdAttribute";
+	/** Password of the LDAP service-user */
+	public static final String LDAP_PASSWORD = "ldapPassword";
+	/** How the LDAP principal is derived from a given username when logging in (DN, SAM, UPN) */
+	public static final String LDAP_PRINCIPAL_SCHEME = "ldapPrincipalScheme";
+	/** Whether to use STARTTLS for the LDAP connection */
+	public static final String LDAP_START_TLS = "ldapStartTls";
+	/** The name of the LDAP service-user */
+	public static final String LDAP_USER = "ldapUser";
+	/** The base-DN for LDAP-users */
+	public static final String LDAP_USER_BASE_DN = "ldapUserBaseDn";
 
-	private static final String DOMAIN_SEPARATOR = "\\";
+	/**
+	 * Set another factory class to be used as JNDI parameter {@code Context.INITIAL_CONTEXT_FACTORY}. This is primarily
+	 * useful for unit testing. The default value is {@code com.sun.jndi.ldap.LdapCtxFactory}.
+	 *
+	 * @param ldapCtxFactory
+	 *            an alternative context factory class to be used.
+	 */
+	public void setLdapCtxFactory(String ldapCtxFactory) {
+		this.ldapCtxFactory = ldapCtxFactory;
+	}
+
+	// Nested class to encapsulate LdapService specific details of credentials and rules for creating JNDI environments.
+	private class LdapCredentials {
+		private String siteName;
+
+		private String principal;
+		private String password;
+		private String ldapHost;
+		private String baseDn;
+		private boolean useStartTls;
+
+		private LdapCredentials(Site site, String username, char[] password, boolean isServiceUser) {
+			org.appng.api.model.Properties siteProperties = site.getProperties();
+			this.siteName = site.getName();
+
+			this.password = String.valueOf(password);
+			this.ldapHost = siteProperties.getString(LDAP_HOST);
+			this.baseDn = siteProperties.getString(LDAP_USER_BASE_DN);
+			this.useStartTls = siteProperties.getBoolean(LDAP_START_TLS);
+
+			String idAttribute = siteProperties.getString(LDAP_ID_ATTRIBUTE);
+			String windowsDomain = siteProperties.getString(LDAP_DOMAIN);
+			String principalScheme = siteProperties.getString(LDAP_PRINCIPAL_SCHEME);
+
+			boolean rawPrincipal = false;
+			if (isServiceUser) {
+				Pattern dnPattern = Pattern
+						.compile("^[a-z0-9+\"\\\\<>; \\n\\d]+?=.+?(,[a-z0-9+\"\\\\<>; \\n\\d]+?=.+?)+$");
+				Matcher dnMatcher = dnPattern.matcher(username);
+				if (dnMatcher.matches())
+					rawPrincipal = true;
+			}
+
+			if (rawPrincipal) {
+				this.principal = username;
+			} else {
+				switch (principalScheme.toUpperCase()) {
+				case "DN":
+					this.principal = idAttribute + "=" + username + "," + baseDn;
+					break;
+				case "UPN":
+					this.principal = username + "@" + windowsDomain;
+					break;
+				case "SAM":
+					this.principal = windowsDomain + SAM_DOMAIN_SEPARATOR + username;
+					break;
+				default:
+					this.principal = username;
+					LOG.info("Unknown keyword '" + principalScheme + "' in site property '" + siteName + "."
+							+ LDAP_PRINCIPAL_SCHEME + "'. Falling back to plain username '" + username
+							+ "' as principal.");
+				}
+			}
+		}
+
+		private Properties getLdapEnv() {
+			Properties env = new Properties();
+			env.put(Context.INITIAL_CONTEXT_FACTORY, ldapCtxFactory);
+			env.put(Context.PROVIDER_URL, ldapHost);
+			env.put("com.sun.jndi.ldap.connect.timeout", LDAP_NETWORK_TIMEOUTS);
+			env.put("com.sun.jndi.ldap.read.timeout", LDAP_NETWORK_TIMEOUTS);
+			if (useStartTls) {
+				// No authentication until we have successfully negotiated STARTTLS.
+				env.put(Context.SECURITY_AUTHENTICATION, "none");
+				return env;
+			} else {
+				if (!ldapHost.toLowerCase().startsWith("ldaps://"))
+					LOG.info("LDAP Configuration of site '" + siteName + "' neither uses LDAP over SSL ('ldaps://')"
+							+ " nor STARTTLS. Credentials will be transmitted as cleartext.");
+				env.put(Context.SECURITY_AUTHENTICATION, "simple");
+				env.put(Context.SECURITY_PRINCIPAL, principal);
+				env.put(Context.SECURITY_CREDENTIALS, password);
+				return env;
+			}
+		}
+
+		private void addToContext(LdapContext ctx) throws NamingException {
+			ctx.addToEnvironment(Context.SECURITY_AUTHENTICATION, "simple");
+			ctx.addToEnvironment(Context.SECURITY_PRINCIPAL, principal);
+			ctx.addToEnvironment(Context.SECURITY_CREDENTIALS, password);
+		}
+	}
 
 	/**
 	 * Tries to login the user with the given username and password.
@@ -81,22 +191,47 @@ public class LdapService {
 	 * @param site
 	 *            the {@link Site} the user wants to login at
 	 * @param username
-	 *            the name of the user, without base-DN (this is set in the site-property {@value #LDAP_USER_BASE_DN})
+	 *            The plain name of the user without base-DN. This name will be mapped to an LDAP principal according to
+	 *            the value of {@value #LDAP_PRINCIPAL_SCHEME}.
+	 *            <ul>
+	 *            <li>"DN": results in <code>{@value #LDAP_ID_ATTRIBUTE}=username,{@value #LDAP_USER_BASE_DN}</code>
+	 *            (this should work with any LDAP server)</li>
+	 *            <li>"UPN": results in <code>username@{@value #LDAP_DOMAIN}</code> (probably most common name format to
+	 *            log on to Active Directory, @see <a https://msdn.microsoft.com/en-us/library/cc223499.aspx">MSDN on
+	 *            LDAP simple authentication</a>)</li>
+	 *            <li>"SAM": results in <code>{@value #LDAP_DOMAIN}&#92;username</code> (name format including
+	 *            sAMAccountName and NetBios name to logon to active Directory)</li>
+	 *            </ul>
 	 * @param password
 	 *            the password of the user
 	 * @return {@code true} if the user could be successfully logged in, {@code false} otherwise
 	 */
+
 	public boolean loginUser(Site site, String username, char[] password) {
-		String ldapHost = site.getProperties().getString(LDAP_HOST);
-		String baseDn = site.getProperties().getString(LDAP_USER_BASE_DN);
-		String ldapDomain = site.getProperties().getString(LDAP_DOMAIN);
-		return loginUser(ldapHost, baseDn, ldapDomain, username, password);
+		LdapCredentials ldapCredentials = new LdapCredentials(site, username, password, false);
+		try {
+			getContext(ldapCredentials);
+			return true;
+		} catch (IOException ioe) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ioe);
+			return false;
+		} catch (NamingException ne) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ne);
+			return false;
+		} finally {
+			closeContext();
+		}
 	}
 
 	/**
 	 * Tries to login the user as a member of at least one of the given groups. Therefore two steps are necessary.
 	 * First, the login of the user with the given password must be successful. Second, the user must be a member of at
 	 * least one group.
+	 * 
+	 * Note that to determine the memberships a service user with credentials taken from {@value #LDAP_USER} and
+	 * {@value #LDAP_PASSWORD}, will be used. This username may be specified as Distinguished Name (DN) e.g. "cn=Service
+	 * User, dc=mycompany, dc=com". If this is the case, it will be used as LDAP principal without mapping. If it is not
+	 * a DN, it will be mapped as described in {@link #loginUser(Site, String, char[])}.
 	 * 
 	 * @param site
 	 *            the {@link Site} the user wants to login at
@@ -114,40 +249,31 @@ public class LdapService {
 	 */
 	public List<String> loginGroup(Site site, String username, char[] password, SubjectImpl subject,
 			List<String> groupNames) {
-
-		String ldapHost = site.getProperties().getString(LDAP_HOST);
-		String baseDn = site.getProperties().getString(LDAP_USER_BASE_DN);
-		String ldapDomain = site.getProperties().getString(LDAP_DOMAIN);
-		String groupBaseDn = site.getProperties().getString(LDAP_GROUP_BASE_DN);
-		String idAttribute = site.getProperties().getString(LDAP_ID_ATTRIBUTE);
-
-		String serviceUser = site.getProperties().getString(LDAP_USER);
-		char[] servicePassword = site.getProperties().getString(LDAP_PASSWORD).toCharArray();
-		boolean isValidUser = loginUser(ldapHost, groupBaseDn, ldapDomain, username, password);
-		if (isValidUser) {
-			return loginGroup(ldapHost, baseDn, ldapDomain, groupBaseDn, idAttribute, serviceUser, servicePassword,
-					username, subject, groupNames);
+		if (loginUser(site, username, password)) {
+			return getUserGroups(username, site, subject, groupNames);
 		}
 		return new ArrayList<String>();
 	}
 
-	private List<String> loginGroup(String ldapHost, String baseDn, String ldapDomain, String groupBaseDn,
-			String idAttribute, String serviceUser, char[] servicePassword, String username, SubjectImpl subject,
-			List<String> groupNames) {
+	private List<String> getUserGroups(String username, Site site, SubjectImpl subject, List<String> groupNames) {
 		List<String> userGroups = new ArrayList<String>();
-		Properties ldapEnv = getLdapEnv(ldapHost, serviceUser, servicePassword);
-		DirContext ctx = null;
+
+		String serviceUser = site.getProperties().getString(LDAP_USER);
+		char[] servicePassword = site.getProperties().getString(LDAP_PASSWORD).toCharArray();
+		LdapCredentials ldapCredentials = new LdapCredentials(site, serviceUser, servicePassword, true);
+
+		String groupBaseDn = site.getProperties().getString(LDAP_GROUP_BASE_DN);
+		String idAttribute = site.getProperties().getString(LDAP_ID_ATTRIBUTE);
+
 		try {
-			username = getUserName(username, ldapDomain);
-			ctx = getContext(ldapEnv);
+			ctx = getContext(ldapCredentials);
 			for (String group : groupNames) {
-				String name = CN_ATTRIBUTE + "=" + group + "," + groupBaseDn;
-				Attributes members = ctx.getAttributes(name, new String[] { MEMBER_ATTRIBUTE });
-				List<String> memberNames = getMemberNames(members);
-				for (String member : memberNames) {
-					Attributes userAttributes = ctx.getAttributes(member);
-					String id = (String) userAttributes.get(idAttribute).get();
-					String realName = (String) userAttributes.get(CN_ATTRIBUTE).get();
+				String groupDn = CN_ATTRIBUTE + "=" + group + "," + groupBaseDn;
+				Attributes memberAttrs = ctx.getAttributes(groupDn, new String[] { MEMBER_ATTRIBUTE });
+				for (String member : getMemberNames(memberAttrs)) {
+					Attributes userAttrs = ctx.getAttributes(member);
+					String id = (String) userAttrs.get(idAttribute).get();
+					String realName = (String) userAttrs.get(CN_ATTRIBUTE).get();
 					if (username.equals(id)) {
 						userGroups.add(group);
 						subject.setName(username);
@@ -155,87 +281,89 @@ public class LdapService {
 					}
 				}
 			}
-		} catch (NamingException e) {
-			logException(ldapHost, serviceUser, e);
+		} catch (IOException ioe) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ioe);
+		} catch (NamingException ne) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ne);
 		} finally {
-			closeContext(ctx);
+			closeContext();
 		}
 		return userGroups;
 	}
 
-	public List<SubjectImpl> getMembersOfGroup(org.appng.api.model.Properties siteProperties, String groupName) {
-
-		String ldapHost = siteProperties.getString(LDAP_HOST);
-		String groupBaseDn = siteProperties.getString(LDAP_GROUP_BASE_DN);
-		String serviceUser = siteProperties.getString(LDAP_USER);
-		char[] servicePassword = siteProperties.getString(LDAP_PASSWORD).toCharArray();
-		String idAttribute = siteProperties.getString(LDAP_ID_ATTRIBUTE);
-
+	/**
+	 * Fetches the members of a given group and returns them as a List of {@link SubjectImpl} objects. Members are LDAP
+	 * Objects in the {@code member} attribute(s) of
+	 * <code>{@value #LDAP_ID_ATTRIBUTE}=groupName,{@value #LDAP_GROUP_BASE_DN}</code>.
+	 * 
+	 * @param site
+	 *            the {@link Site} in which the application using this group is running
+	 * @param groupName
+	 *            the name of the group whose members should be fetched
+	 * @return the members of the groupName (may be empty)
+	 */
+	public List<SubjectImpl> getMembersOfGroup(Site site, String groupName) {
 		List<SubjectImpl> subjects = new ArrayList<SubjectImpl>();
-		Properties ldapEnv = getLdapEnv(ldapHost, serviceUser, servicePassword);
-		DirContext ctx = null;
+
+		String serviceUser = site.getProperties().getString(LDAP_USER);
+		char[] servicePassword = site.getProperties().getString(LDAP_PASSWORD).toCharArray();
+		LdapCredentials ldapCredentials = new LdapCredentials(site, serviceUser, servicePassword, true);
+
+		String groupBaseDn = site.getProperties().getString(LDAP_GROUP_BASE_DN);
+		String idAttribute = site.getProperties().getString(LDAP_ID_ATTRIBUTE);
+
 		try {
-			ctx = getContext(ldapEnv);
+			ctx = getContext(ldapCredentials);
 			String groupDn = CN_ATTRIBUTE + "=" + groupName + "," + groupBaseDn;
-			Attributes members = ctx.getAttributes(groupDn, new String[] { MEMBER_ATTRIBUTE });
-			List<String> membersOfGroup = getMemberNames(members);
-			for (String member : membersOfGroup) {
-				Attributes userAttributes = ctx.getAttributes(member);
-				String realName = (String) userAttributes.get(CN_ATTRIBUTE).get();
-				String username = (String) userAttributes.get(idAttribute).get();
-				String email = (String) userAttributes.get(MAIL_ATTRIBUTE).get();
+			Attributes memberAttrs = ctx.getAttributes(groupDn, new String[] { MEMBER_ATTRIBUTE });
+			for (String member : getMemberNames(memberAttrs)) {
+				Attributes userAttrs = ctx.getAttributes(member);
+				String realName = (String) userAttrs.get(CN_ATTRIBUTE).get();
+				String username = (String) userAttrs.get(idAttribute).get();
+				String email = (String) userAttrs.get(MAIL_ATTRIBUTE).get();
 				SubjectImpl ldapSubject = new SubjectImpl();
 				ldapSubject.setName(username);
 				ldapSubject.setRealname(realName);
 				ldapSubject.setEmail(email.toLowerCase());
 				subjects.add(ldapSubject);
 			}
-
-		} catch (NamingException e) {
-			logException(ldapHost, serviceUser, e);
+		} catch (IOException ioe) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ioe);
+		} catch (NamingException ne) {
+			logException(ldapCredentials.ldapHost, ldapCredentials.principal, ne);
 		} finally {
-			closeContext(ctx);
+			closeContext();
 		}
+
 		return subjects;
 	}
 
-	private boolean loginUser(String ldapHost, String baseDn, String ldapDomain, String username, char[] password) {
-		String principal = null;
-		if (StringUtils.isNotBlank(ldapDomain)) {
-			if (username.startsWith(ldapDomain)) {
-				principal = username;
-				username = getUserName(username, ldapDomain);
-			} else {
-				principal = ldapDomain + DOMAIN_SEPARATOR + username;
-			}
-		} else {
-			principal = CN_ATTRIBUTE + "=" + username + "," + baseDn;
-		}
+	private LdapContext getContext(LdapCredentials ldapCredentials) throws NamingException, IOException {
+		Properties env = ldapCredentials.getLdapEnv();
+		ctx = new InitialLdapContext(env, null);
 
-		Properties env = getLdapEnv(ldapHost, principal, password);
-		DirContext ctx = null;
-		try {
-			ctx = getContext(env);
-			return true;
-		} catch (NamingException e) {
-			logException(ldapHost, principal, e);
-		} finally {
-			closeContext(ctx);
+		if (ldapCredentials.useStartTls) {
+			tls = (StartTlsResponse) ctx.extendedOperation(new StartTlsRequest());
+			tls.setHostnameVerifier(new HostnameVerifier() {
+				@Override
+				public boolean verify(String hostname, SSLSession session) {
+					return true; // Allow STARTTLS with plain IP addresses.
+				}
+			});
+			tls.negotiate();
+			ldapCredentials.addToContext(ctx);
+			ctx.reconnect(null);
 		}
-		return false;
+		return ctx;
 	}
 
-	protected DirContext getContext(Properties env) throws NamingException {
-		return new InitialDirContext(env);
-	}
-
-	private void logException(String host, String user, NamingException e) {
+	private void logException(String host, String principal, Exception e) {
 		String message;
-		String exceptionInfo = "(" + e.getClass().getName() + ": " + e.getMessage() + ")";
+		String excInfo = "(" + e.getClass().getName() + ": " + e.getMessage() + ")";
 		if (e instanceof AuthenticationException) {
-			message = "failed to login user '" + user + "' on host '" + host + "' " + exceptionInfo;
+			message = "failed to login user '" + principal + "' on host '" + host + "' " + excInfo;
 		} else {
-			message = "LDAP operation failed on host '" + host + "' with user '" + user + "'" + exceptionInfo;
+			message = "LDAP operation failed on host '" + host + "' with principal '" + principal + "' " + excInfo;
 		}
 		if (LOG.isDebugEnabled()) {
 			LOG.debug(message, e);
@@ -244,48 +372,34 @@ public class LdapService {
 		}
 	}
 
-	private String getUserName(String username, String ldapDomain) {
-		if (null != ldapDomain) {
-			if (username.startsWith(ldapDomain)) {
-				return username.substring(username.indexOf(DOMAIN_SEPARATOR) + 1);
+	private void closeContext() {
+		if (tls != null) {
+			try {
+				tls.close();
+			} catch (IOException ioe) {
+				LOG.warn("error closing TLS connection", ioe);
 			}
 		}
-		return username;
-	}
-
-	private void closeContext(DirContext ctx) {
-		try {
-			if (null != ctx) {
+		if (ctx != null) {
+			try {
 				ctx.close();
+			} catch (NamingException ne) {
+				LOG.warn("error closing LDAP context", ne);
 			}
-		} catch (NamingException e) {
-			LOG.warn("error closing context", e);
 		}
 	}
 
-	private Properties getLdapEnv(String ldapHost, String username, char[] password) {
-		Properties env = new Properties();
-		env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-		env.put(Context.PROVIDER_URL, ldapHost);
-		env.put(Context.SECURITY_AUTHENTICATION, "simple");
-		env.put(Context.SECURITY_PRINCIPAL, username);
-		env.put(Context.SECURITY_CREDENTIALS, String.valueOf(password));
-		return env;
-	}
-
-	protected List<String> getMemberNames(Attributes attributes) throws NamingException {
-		List<String> result = new ArrayList<String>();
-		NamingEnumeration<? extends Attribute> allAttributes = attributes.getAll();
-		while (allAttributes.hasMoreElements()) {
-			Attribute attribute = allAttributes.nextElement();
-			NamingEnumeration<?> subAttributes = attribute.getAll();
-			while (subAttributes.hasMoreElements()) {
-				Object object = subAttributes.nextElement();
-				result.add(object.toString());
-			}
+	private List<String> getMemberNames(Attributes attributes) throws NamingException {
+		Attribute memberAttr = attributes.get(MEMBER_ATTRIBUTE);
+		if (memberAttr == null)
+			return Collections.emptyList();
+		else {
+			List<String> result = new ArrayList<String>();
+			NamingEnumeration<?> memberAttrEnum = memberAttr.getAll();
+			while (memberAttrEnum.hasMoreElements())
+				result.add(memberAttrEnum.nextElement().toString());
+			return result;
 		}
-		return result;
 	}
 
 }
-

--- a/appng-core/src/main/java/org/appng/core/service/PropertySupport.java
+++ b/appng-core/src/main/java/org/appng/core/service/PropertySupport.java
@@ -269,13 +269,15 @@ public class PropertySupport {
 		xssExceptions.append(managerPath + "/" + site.getName() + "/appng-manager" + StringUtils.LF);
 		addSiteProperty(SiteProperties.XSS_EXCEPTIONS, xssExceptions.toString(), true);
 
-		addSiteProperty(LdapService.LDAP_HOST, "ldap:<host>:<port>");
+		addSiteProperty(LdapService.LDAP_HOST, "ldap(s):<host>:<port>");
 		addSiteProperty(LdapService.LDAP_USER_BASE_DN, "OU=Users,DC=example,DC=com");
 		addSiteProperty(LdapService.LDAP_GROUP_BASE_DN, "OU=Groups,DC=example,DC=com");
 		addSiteProperty(LdapService.LDAP_USER, "serviceUser");
 		addSiteProperty(LdapService.LDAP_PASSWORD, "secret");
 		addSiteProperty(LdapService.LDAP_DOMAIN, "EXAMPLE");
 		addSiteProperty(LdapService.LDAP_ID_ATTRIBUTE, "sAMAccountName");
+		addSiteProperty(LdapService.LDAP_PRINCIPAL_SCHEME, "SAM");
+		addSiteProperty(LdapService.LDAP_START_TLS, false);
 
 		propertyHolder.setFinal();
 	}

--- a/appng-core/src/main/resources/org/appng/core/site-config.properties
+++ b/appng-core/src/main/resources/org/appng/core/site-config.properties
@@ -37,11 +37,13 @@ site.indexQueueSize = The queue size used for document indexing
 site.indexTimeout = The timeout in milliseconds for indexing
 site.ldapDomain = The Domain for the LDAP authentication
 site.ldapGroupBaseDn = The base-DN for LDAP-groups
-site.ldapHost = The LDAP host
+site.ldapHost = The LDAP host in provider URL format ("ldap(s)://<host>:<port>"). Note that you might need to add CA certificates to the truststore of the executing JVM if you enable "ldaps://".
 site.ldapIdAttribute = The name of the LDAP-attribute containing the user-id used for authentication
 site.ldapPassword = Password of the LDAP service-user
-site.ldapUser = The name of the LDAP service-user
-site.ldapUserBaseDn = The base-DN for LDAP-users
+site.ldapUser = The name of the LDAP service-user for general LDAP lookups. If the value is a Distinguished Name (e.g. "cn=Service User,dc=mycompany,dc=com") it will be used directly as LDAP principal. Otherwise the principal will be derived according to the value specified for ${site.ldapPrincipalScheme}.
+site.ldapUserBaseDn = The base-DN which is used to map a plain username to a Distinguished Name, if "DN" is used as principal scheme (see property "ldapPrincipalScheme").
+site.ldapPrincipalScheme = How the LDAP principal is built from a given username when logging in. ["DN": results in "${site.ldapIdAttribute}=<username>,${site.ldapUserBaseDn}" - "UPN": results in "<username>@${site.ldapDomain}" - "SAM": results in "${site.ldapDomain}\\\\<username>"]. "UPN" and "SAM" are ActiveDirectory specific and "SAM" is the default to stay backward compatible.
+site.ldapStartTls = Use STARTTLS for the LDAP connection. If you set this to "true" the value of ${site.ldapHost} should begin with "ldap://" (not "ldaps://"), because STARTTLS and LDAP over SSL (which is used when "ldaps://" is in place) are mutually exclusive.
 site.locale = The default locale for the site. Use one of java.util.Locale.getAvailableLocales()
 site.mailDisabled = Set to 'true' to disable mailing and log the e-mails instead.
 site.mailHost = The mail-host to use.

--- a/appng-core/src/test/java/org/appng/core/service/LdapContextFactoryMock.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapContextFactoryMock.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.appng.core.service;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+
+public class LdapContextFactoryMock implements InitialContextFactory {
+
+	private static HashMap<String, LdapContextMock> contexts = new HashMap<String, LdapContextMock>();
+
+	public LdapContextFactoryMock() {
+		// JNDI needs a public default constructor.
+	}
+
+	public static LdapContextMock setup(String userPrincipal, String userPassword, String servicePrincipal,
+			String servicePassword, HashMap<String, Object> siteProperties) throws NamingException, IOException {
+		// We need something to identify the context to be returned, when JNDI calls getInitialContext().
+		// PROVIDER_URL is used as key, because it is irrelevant for the tests (will be in Context.PROVIDER_URL later).
+		String testId = (String) siteProperties.get(LdapService.LDAP_HOST);
+
+		LdapContextMock ctx;
+		if (!contexts.containsKey(testId)) {
+			ctx = new LdapContextMock(userPrincipal, userPassword, servicePrincipal, servicePassword, siteProperties);
+			contexts.put(testId, ctx);
+		} else {
+			ctx = contexts.get(testId);
+		}
+		return ctx;
+	}
+
+	@Override
+	public Context getInitialContext(Hashtable<?, ?> env) throws NamingException {
+		String testId = (String) env.get(Context.PROVIDER_URL);
+		if (!contexts.containsKey(testId))
+			throw new NamingException("No context prepared for testId '" + testId + "'. Error in unit tests!");
+
+		LdapContextMock ctx = contexts.get(testId);
+		ctx.init(env);
+		if (!ctx.useTls)
+			ctx.reconnect(null);
+
+		return ctx;
+	}
+}

--- a/appng-core/src/test/java/org/appng/core/service/LdapContextFactoryMock.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapContextFactoryMock.java
@@ -27,10 +27,6 @@ public class LdapContextFactoryMock implements InitialContextFactory {
 
 	private static HashMap<String, LdapContextMock> contexts = new HashMap<String, LdapContextMock>();
 
-	public LdapContextFactoryMock() {
-		// JNDI needs a public default constructor.
-	}
-
 	public static LdapContextMock setup(String userPrincipal, String userPassword, String servicePrincipal,
 			String servicePassword, HashMap<String, Object> siteProperties) throws NamingException, IOException {
 		// We need something to identify the context to be returned, when JNDI calls getInitialContext().

--- a/appng-core/src/test/java/org/appng/core/service/LdapContextMock.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapContextMock.java
@@ -1,0 +1,585 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.appng.core.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.NoSuchElementException;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.ExtendedRequest;
+import javax.naming.ldap.ExtendedResponse;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.StartTlsResponse;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/*
+ * Implementation of the LdapContext Interface.
+ * Substitutes what is normally {@code com.sun.jndi.ldap.LdapCtx} within the private field {@code defaultInitCtx} of
+ * {@InitialContext} after it has been initialized.
+ * 
+ * This is a partial mock with auto-generated stubs for the {@LdapContext} methods to be more flexible than a complete mock.
+ * (We could cheat and extend the concrete class {@link InitialLdapContext}, but a facade class inside a facade looks funny to me.)
+ */
+public class LdapContextMock implements LdapContext {
+
+	public static final String MSG_WRONG_USER = "Sorry kiddo. You got the gift, but it looks like you're waiting for something.";
+	public static final String MSG_WRONG_PASS = "Ah ah ah, you didn't say the magic word!";
+
+	public static final String MOCKED_ID_ATTR = "sAMAccountName";
+	public static final String MOCKED_GROUP_NAME = "logingroup";
+	public static final String[] MOCKED_GROUP_MEMBERS = new String[] { "uid=aziz,ou=users,l=egypt",
+			"uid=aziz' brother,ou=users,l=egypt" };
+
+	public boolean useTls;
+
+	@Mock
+	private StartTlsResponse mockTlsResponse;
+
+	private Hashtable<?, ?> env;
+
+	private String mockedUserPrincipal;
+	private String mockedUserPassword;
+	private String mockedServicePrincipal;
+	private String mockedServicePassword;
+
+	private String userBaseDn;
+	private String groupBaseDn;
+
+	private class MemberEnumerationMock implements NamingEnumeration<String> {
+		int idx;
+		String[] names;
+
+		public MemberEnumerationMock(String[] names) {
+			idx = 0;
+			this.names = names;
+		}
+
+		@Override
+		public boolean hasMoreElements() {
+			return idx < names.length;
+		}
+
+		@Override
+		public String nextElement() throws NoSuchElementException {
+			if (hasMoreElements())
+				return names[idx++];
+			else
+				throw new NoSuchElementException("Naming cache is 'a few raisins short of a full scoop'.");
+		}
+
+		@Override
+		public boolean hasMore() throws NamingException {
+			return idx < names.length;
+		}
+
+		@Override
+		public String next() throws NamingException {
+			if (hasMoreElements())
+				return names[idx++];
+			else
+				throw new NamingException("Naming cache is 'a few raisins short of a full scoop'.");
+		}
+
+		@Override
+		public void close() throws NamingException {
+		}
+	}
+
+	// Keeps track of (simulated) Exceptions to make them available to the unit tests.
+	public ArrayList<Exception> exceptionHistory = new ArrayList<Exception>(2);
+
+	public LdapContextMock(String userPrincipal, String userPassword, String servicePrincipal, String servicePassword,
+			HashMap<String, Object> siteProperties) throws NamingException, IOException {
+		mockedUserPrincipal = userPrincipal != null ? userPrincipal : "not set";
+		mockedUserPassword = userPassword != null ? userPassword : "not set";
+		mockedServicePrincipal = servicePrincipal != null ? servicePrincipal : "not set";
+		mockedServicePassword = servicePassword != null ? servicePassword : "not set";
+
+		userBaseDn = (String) siteProperties.get(LdapService.LDAP_USER_BASE_DN);
+		groupBaseDn = (String) siteProperties.get(LdapService.LDAP_GROUP_BASE_DN);
+
+		MockitoAnnotations.initMocks(this);
+		Object startTlsProp = siteProperties.get(LdapService.LDAP_START_TLS);
+		if (startTlsProp != null && ((Boolean) startTlsProp).booleanValue()) {
+			useTls = true;
+			Mockito.when(mockTlsResponse.negotiate()).thenReturn(null);
+		} else {
+			useTls = false;
+			Mockito.when(mockTlsResponse.negotiate()).thenThrow(new IOException("TLS intentionally failed."));
+		}
+	}
+
+	public void init(Hashtable<?, ?> env) {
+		this.env = env;
+
+	}
+
+	private <T extends Exception> void stackAndThrow(T ex) throws T {
+		exceptionHistory.add(ex);
+		throw ex;
+	}
+
+	@Override
+	public ExtendedResponse extendedOperation(ExtendedRequest request) throws NamingException {
+		return mockTlsResponse;
+	}
+
+	@Override
+	public void reconnect(Control[] connCtls) throws NamingException {
+		String envPrincipal = (String) env.get(Context.SECURITY_PRINCIPAL);
+		String envPassword = (String) env.get(Context.SECURITY_CREDENTIALS);
+
+		if (mockedServicePrincipal.equals(envPrincipal)) {
+			if (!mockedServicePassword.equals(envPassword))
+				stackAndThrow(new NamingException(MSG_WRONG_PASS));
+		} else {
+			if (!mockedUserPrincipal.equals(envPrincipal))
+				stackAndThrow(new NamingException(MSG_WRONG_USER));
+			if (!mockedUserPassword.equals(envPassword))
+				stackAndThrow(new NamingException(MSG_WRONG_PASS));
+		}
+	}
+
+	@Override
+	public Attributes getAttributes(String name, String[] attrIds) throws NamingException {
+		if (name.endsWith(groupBaseDn)) {
+			Answer<NamingEnumeration<?>> attrEnumAnswer;
+			Attributes groupAttrs = Mockito.mock(Attributes.class);
+			Attribute memberAttr = Mockito.mock(Attribute.class);
+
+			if (name.toLowerCase().startsWith(("cn=" + MOCKED_GROUP_NAME).toLowerCase())) {
+				attrEnumAnswer = new Answer<NamingEnumeration<?>>() {
+					public NamingEnumeration<String> answer(InvocationOnMock invocation) throws Throwable {
+						return new MemberEnumerationMock(MOCKED_GROUP_MEMBERS);
+					}
+				};
+			} else {
+				attrEnumAnswer = new Answer<NamingEnumeration<?>>() {
+
+					public NamingEnumeration<String> answer(InvocationOnMock invocation) throws Throwable {
+						return new MemberEnumerationMock(new String[0]);
+					}
+				};
+			}
+
+			Mockito.when(groupAttrs.get("member")).thenReturn(memberAttr);
+			Mockito.when(memberAttr.getAll()).thenAnswer(attrEnumAnswer);
+
+			return groupAttrs;
+		} else if (name.endsWith(userBaseDn)) {
+
+			Attributes memberAttrs = Mockito.mock(Attributes.class);
+
+			Attribute idAttr = Mockito.mock(Attribute.class);
+			if (name.equals(MOCKED_GROUP_MEMBERS[0])) {
+				Mockito.when(idAttr.get()).thenReturn("aziz");
+				Mockito.when(memberAttrs.get(MOCKED_ID_ATTR)).thenReturn(idAttr);
+			} else {
+				Mockito.when(idAttr.get()).thenReturn("aziz' brother");
+				Mockito.when(memberAttrs.get(MOCKED_ID_ATTR)).thenReturn(idAttr);
+			}
+
+			Attribute dummyAttr = Mockito.mock(Attribute.class);
+			Mockito.when(dummyAttr.get()).thenReturn("Dummy");
+			// Is there a way to say "Mockito.notmatches()"? The negative lookaround regex works, but is a bit overkill.
+			Mockito.when(memberAttrs.get(Mockito.matches("^((?!" + MOCKED_ID_ATTR + ").)*$"))).thenReturn(dummyAttr);
+
+			return memberAttrs;
+		} else {
+			throw new NamingException(
+					"No attributes are prepared to be be returned from DN '" + name + "'. Error in unit tests!");
+		}
+	}
+
+	@Override
+	public void bind(Name arg0, Object arg1, Attributes arg2) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void bind(String arg0, Object arg1, Attributes arg2) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public DirContext createSubcontext(Name arg0, Attributes arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public DirContext createSubcontext(String arg0, Attributes arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Attributes getAttributes(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Attributes getAttributes(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Attributes getAttributes(Name arg0, String[] arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public DirContext getSchema(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public DirContext getSchema(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public DirContext getSchemaClassDefinition(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public DirContext getSchemaClassDefinition(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void modifyAttributes(Name arg0, ModificationItem[] arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void modifyAttributes(String arg0, ModificationItem[] arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void modifyAttributes(Name arg0, int arg1, Attributes arg2) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void modifyAttributes(String arg0, int arg1, Attributes arg2) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void rebind(Name arg0, Object arg1, Attributes arg2) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void rebind(String arg0, Object arg1, Attributes arg2) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(Name arg0, Attributes arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(String arg0, Attributes arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(Name arg0, Attributes arg1, String[] arg2) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(String arg0, Attributes arg1, String[] arg2) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(Name arg0, String arg1, SearchControls arg2) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(String arg0, String arg1, SearchControls arg2)
+			throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(Name arg0, String arg1, Object[] arg2, SearchControls arg3)
+			throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<SearchResult> search(String arg0, String arg1, Object[] arg2, SearchControls arg3)
+			throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Object addToEnvironment(String arg0, Object arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void bind(Name arg0, Object arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void bind(String arg0, Object arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void close() throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public Name composeName(Name arg0, Name arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String composeName(String arg0, String arg1) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Context createSubcontext(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Context createSubcontext(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void destroySubcontext(Name arg0) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void destroySubcontext(String arg0) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public Hashtable<?, ?> getEnvironment() throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getNameInNamespace() throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NameParser getNameParser(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NameParser getNameParser(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<NameClassPair> list(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<NameClassPair> list(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<Binding> listBindings(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public NamingEnumeration<Binding> listBindings(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Object lookup(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Object lookup(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Object lookupLink(Name arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Object lookupLink(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void rebind(Name arg0, Object arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void rebind(String arg0, Object arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public Object removeFromEnvironment(String arg0) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void rename(Name arg0, Name arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void rename(String arg0, String arg1) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void unbind(Name arg0) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public void unbind(String arg0) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+	@Override
+	public Control[] getConnectControls() throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Control[] getRequestControls() throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Control[] getResponseControls() throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public LdapContext newInstance(Control[] requestControls) throws NamingException {
+		// Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void setRequestControls(Control[] requestControls) throws NamingException {
+		// Auto-generated method stub
+
+	}
+
+}

--- a/appng-core/src/test/java/org/appng/core/service/LdapServiceTest.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapServiceTest.java
@@ -203,7 +203,9 @@ public class LdapServiceTest {
 
 	@Test
 	public void testUsersOfGroup() throws NamingException, IOException {
-		List<SubjectImpl> resultGroups;
+		List<SubjectImpl> resultSubjects;
+		String[] expectSubjNames = new String[] { "aziz", "aziz' brother" };
+		String[] expectSubjRealNames = new String[] { "Dummy", "Dummy" };
 
 		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
 		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
@@ -213,17 +215,20 @@ public class LdapServiceTest {
 		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "ou=groups,l=egypt");
 
 		setup("aziz@egypt", "light", "mondoshawan@egypt", "stones");
-		resultGroups = ldapService.getMembersOfGroup(mockedSite, LdapContextMock.MOCKED_GROUP_NAME);
+		resultSubjects = ldapService.getMembersOfGroup(mockedSite, LdapContextMock.MOCKED_GROUP_NAME);
 
-		// FIXME: This is not a valid comparison, but works as long as some assumptions remain stable.
-		Assert.assertEquals("[Subject#null_aziz, Subject#null_aziz' brother]", resultGroups.toString());
+		Assert.assertEquals(resultSubjects.size(), 2);
+		for (int idx = 0; idx < 2; idx++) {
+			Assert.assertEquals(resultSubjects.get(idx).getName(), expectSubjNames[idx]);
+			Assert.assertEquals(resultSubjects.get(idx).getRealname(), expectSubjRealNames[idx]);
+			Assert.assertFalse(resultSubjects.get(idx).isAuthenticated());
+		}
 	}
 
 	@Test
 	public void testLoginUserStartTls() throws NamingException, IOException {
 		boolean success;
 
-		// DN
 		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "DN");
 		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "l=egypt");
 		sitePropertyMocks.put(LdapService.LDAP_ID_ATTRIBUTE, "uid");

--- a/appng-core/src/test/java/org/appng/core/service/LdapServiceTest.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapServiceTest.java
@@ -15,16 +15,13 @@
  */
 package org.appng.core.service;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
-import javax.naming.Context;
 import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.DirContext;
 
-import org.appng.api.model.Properties;
 import org.appng.api.model.Site;
 import org.appng.core.domain.SubjectImpl;
 import org.junit.Assert;
@@ -33,108 +30,206 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-public class LdapServiceTest extends LdapService {
+public class LdapServiceTest {
 
-	private static final String USERS = "users";
-	private static final String PASSWORD = "password";
-	private static final String USERNAME = "username";
-	private static final String SERVICEUSER = "serviceuser";
+	private HashMap<String, Object> sitePropertyMocks;
+	private LdapService ldapService;
 
 	@Mock
-	private DirContext dirContext;
+	private Site mockedSite;
 
 	@Mock
-	private Site site;
+	private SubjectImpl mockedSubject;
 
 	@Mock
-	private Properties properties;
+	private org.appng.api.model.Properties mockedProperties;
 
-	private java.util.Properties env;
+	public LdapServiceTest() {
+		ldapService = new LdapService();
+		ldapService.setLdapCtxFactory("org.appng.core.service.LdapContextFactoryMock");
 
-	public java.util.Properties setup(String password) {
+		sitePropertyMocks = new HashMap<String, Object>();
+		sitePropertyMocks.put(LdapService.LDAP_HOST, "ldap://localhost:389");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "ou=users,dc=example,dc=com");
+		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "ou=groups,dc=example,dc=com");
+		sitePropertyMocks.put(LdapService.LDAP_USER, "serviceuser");
+		sitePropertyMocks.put(LdapService.LDAP_PASSWORD, "inferno");
+		sitePropertyMocks.put(LdapService.LDAP_PRINCIPAL_SCHEME, "SAM");
+		sitePropertyMocks.put(LdapService.LDAP_START_TLS, false);
+		sitePropertyMocks.put(LdapService.LDAP_DOMAIN, "EXAMPLE");
+		sitePropertyMocks.put(LdapService.LDAP_ID_ATTRIBUTE, LdapContextMock.MOCKED_ID_ATTR);
+	}
+
+	public LdapContextMock setup(String userPrincipal, String userPassword, String servicePrincipal,
+			String servicePassword) throws NamingException, IOException {
 		MockitoAnnotations.initMocks(this);
-		Mockito.when(site.getProperties()).thenReturn(properties);
-		Mockito.when(properties.getString(LDAP_DOMAIN)).thenReturn("EXAMPLE");
-		Mockito.when(properties.getString(LDAP_GROUP_BASE_DN)).thenReturn("OU=Groups,DC=example,DC=com");
-		Mockito.when(properties.getString(LDAP_HOST)).thenReturn("ldap:localhost:389");
-		Mockito.when(properties.getString(LDAP_ID_ATTRIBUTE)).thenReturn("cn");
-		Mockito.when(properties.getString(LDAP_PASSWORD)).thenReturn(password);
-		Mockito.when(properties.getString(LDAP_USER)).thenReturn(SERVICEUSER);
-		Mockito.when(properties.getString(LDAP_USER_BASE_DN)).thenReturn("OU=Users,DC=example,DC=com");
+		StackTraceElement caller = Thread.currentThread().getStackTrace()[2];
 
-		java.util.Properties expected = new java.util.Properties();
-		expected.put(Context.PROVIDER_URL, "ldap:localhost:389");
-		expected.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-		expected.put(Context.SECURITY_PRINCIPAL, "EXAMPLE\\username");
-		expected.put(Context.SECURITY_AUTHENTICATION, "simple");
-		expected.put(Context.SECURITY_CREDENTIALS, password);
-		return expected;
-	}
+		String testId = caller.getMethodName() + ":" + caller.getLineNumber();
+		sitePropertyMocks.replace(LdapService.LDAP_HOST, "ldaps://" + testId);
 
-	@Test
-	public void testLoginUser() {
-		java.util.Properties expected = setup(PASSWORD);
-		boolean success = this.loginUser(site, USERNAME, PASSWORD.toCharArray());
-		Assert.assertTrue(success);
-		Assert.assertEquals(expected, env);
-	}
-
-	@Test
-	public void testLoginUserFail() {
-		String password = "wrongPassword";
-		java.util.Properties expected = setup(password);
-		boolean success = this.loginUser(site, "EXAMPLE\\username", password.toCharArray());
-		Assert.assertFalse(success);
-		Assert.assertEquals(expected, env);
-	}
-
-	@Test
-	public void testLoginGroup() throws NamingException {
-		java.util.Properties expected = setup(PASSWORD);
-		expected.put(Context.SECURITY_PRINCIPAL, SERVICEUSER);
-		setAttributes(USERNAME);
-		SubjectImpl subject = new SubjectImpl();
-		List<String> loginGroup = this
-				.loginGroup(site, USERNAME, PASSWORD.toCharArray(), subject, Arrays.asList(USERS));
-		Assert.assertEquals(Arrays.asList(USERS), loginGroup);
-		Assert.assertEquals(expected, env);
-		Assert.assertEquals("username", subject.getName());
-		Assert.assertEquals("username", subject.getRealname());
-	}
-
-	@Test
-	public void testLoginGroupFail() throws NamingException {
-		java.util.Properties expected = setup(PASSWORD);
-		expected.put(Context.SECURITY_PRINCIPAL, SERVICEUSER);
-		setAttributes("");
-		SubjectImpl subject = new SubjectImpl();
-		List<String> loginGroups = this.loginGroup(site, USERNAME, PASSWORD.toCharArray(), subject,
-				Arrays.asList(USERS));
-		Assert.assertTrue(loginGroups.isEmpty());
-		Assert.assertEquals(expected, env);
-		Assert.assertNull(subject.getName());
-		Assert.assertNull(subject.getRealname());
-	}
-
-	public void setAttributes(String userName) throws NamingException {
-		Attributes attributes = Mockito.mock(Attributes.class);
-		Mockito.when(dirContext.getAttributes(USERS)).thenReturn(attributes);
-		Attribute attribute = Mockito.mock(Attribute.class);
-		Mockito.when(attributes.get("cn")).thenReturn(attribute);
-		Mockito.when(attribute.get()).thenReturn(userName);
-	}
-
-	@Override
-	protected DirContext getContext(java.util.Properties env) throws NamingException {
-		this.env = env;
-		if (!env.get(Context.SECURITY_CREDENTIALS).equals(PASSWORD)) {
-			throw new NamingException("wrong password");
+		Mockito.when(mockedSite.getName()).thenReturn(caller.getMethodName());
+		Mockito.when(mockedSite.getProperties()).thenReturn(mockedProperties);
+		for (String propName : sitePropertyMocks.keySet()) {
+			Object propVal = sitePropertyMocks.get(propName);
+			if (propVal instanceof String) {
+				Mockito.when(mockedProperties.getString(propName)).thenReturn((String) propVal);
+			} else if (propVal instanceof Boolean) {
+				Mockito.when(mockedProperties.getBoolean(propName)).thenReturn(((Boolean) propVal).booleanValue());
+			}
 		}
-		return dirContext;
+
+		return LdapContextFactoryMock.setup(userPrincipal, userPassword, servicePrincipal, servicePassword,
+				sitePropertyMocks);
 	}
 
-	@Override
-	protected List<String> getMemberNames(Attributes attributes) throws NamingException {
-		return Arrays.asList(USERS);
+	@Test
+	public void testLoginUserSucces() throws NamingException, IOException {
+		boolean success;
+
+		// DN
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "DN");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_ID_ATTRIBUTE, "uid");
+		setup("uid=aziz,l=egypt", "light", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		Assert.assertTrue(success);
+
+		// UPN
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		setup("aziz@egypt", "light", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		Assert.assertTrue(success);
+
+		// SAM
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "SAM");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		setup("egypt\\aziz", "light", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		Assert.assertTrue(success);
+
+		// Fallback to plain name
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "bogus");
+		setup("aziz", "light", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		Assert.assertTrue(success);
+	}
+
+	@Test
+	public void testLoginUserFailure() throws NamingException, IOException {
+		boolean success;
+		List<Exception> exList;
+		Exception ex;
+		LdapContextMock ldapContextMock;
+
+		// Principal wrong
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "SAM");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		ldapContextMock = setup("bielefeld\\aziz", "light", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		exList = ldapContextMock.exceptionHistory;
+		ex = exList.size() > 0 ? exList.get(exList.size() - 1) : new Exception("Placeholder - nothing was thrown.");
+		Assert.assertFalse(success);
+		Assert.assertEquals(LdapContextMock.MSG_WRONG_USER, ex.getMessage());
+
+		// Password wrong
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "SAM");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		ldapContextMock = setup("egypt\\aziz", "shadow", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		Assert.assertFalse(success);
+		exList = ldapContextMock.exceptionHistory;
+		ex = exList.size() > 0 ? exList.get(exList.size() - 1) : new Exception("Placeholder - nothing was thrown.");
+		Assert.assertFalse(success);
+		Assert.assertEquals(LdapContextMock.MSG_WRONG_PASS, ex.getMessage());
+	}
+
+	@Test
+	public void testLoginGroupExistent() throws NamingException, IOException {
+		List<String> searchedGroups;
+		List<String> resultGroups;
+
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		sitePropertyMocks.put(LdapService.LDAP_USER, "mondoshawan");
+		sitePropertyMocks.put(LdapService.LDAP_PASSWORD, "stones");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "ou=users,l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "ou=groups,l=egypt");
+
+		setup("aziz@egypt", "light", "mondoshawan@egypt", "stones");
+		searchedGroups = Arrays.asList(LdapContextMock.MOCKED_GROUP_NAME);
+		resultGroups = ldapService.loginGroup(mockedSite, "aziz", "light".toCharArray(), mockedSubject, searchedGroups);
+		Assert.assertArrayEquals(searchedGroups.toArray(new String[0]), resultGroups.toArray(new String[0]));
+	}
+
+	@Test
+	// The same as testLoginGroupExistent(), but additionally tests, if service user logins with DN do work.
+	public void testLoginGroupExistentServiceUserDirectDN() throws NamingException, IOException {
+		List<String> searchedGroups;
+		List<String> resultGroups;
+
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		sitePropertyMocks.put(LdapService.LDAP_USER, "cn=mondoshawan,l=homeplanet");
+		sitePropertyMocks.put(LdapService.LDAP_PASSWORD, "stones");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "ou=users,l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "ou=groups,l=egypt");
+
+		setup("aziz@egypt", "light", "cn=mondoshawan,l=homeplanet", "stones");
+		searchedGroups = Arrays.asList(LdapContextMock.MOCKED_GROUP_NAME);
+		resultGroups = ldapService.loginGroup(mockedSite, "aziz", "light".toCharArray(), mockedSubject, searchedGroups);
+		Assert.assertArrayEquals(searchedGroups.toArray(new String[0]), resultGroups.toArray(new String[0]));
+	}
+
+	@Test
+	public void testLoginGroupMissing() throws NamingException, IOException {
+		List<String> searchedGroups;
+		List<String> resultGroups;
+
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		sitePropertyMocks.put(LdapService.LDAP_USER, "mondoshawan");
+		sitePropertyMocks.put(LdapService.LDAP_PASSWORD, "stones");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "ou=users,l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "ou=groups,l=egypt");
+
+		setup("aziz@egypt", "light", "mondoshawan@egypt", "stones");
+		searchedGroups = Arrays.asList(
+				"Well, if there's a bright center to the universe, you're on the usergroup that it's farthest from.");
+		resultGroups = ldapService.loginGroup(mockedSite, "aziz", "light".toCharArray(), mockedSubject, searchedGroups);
+		Assert.assertArrayEquals(new String[0], resultGroups.toArray(new String[0]));
+	}
+
+	@Test
+	public void testUsersOfGroup() throws NamingException, IOException {
+		List<SubjectImpl> resultGroups;
+
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		sitePropertyMocks.put(LdapService.LDAP_USER, "mondoshawan");
+		sitePropertyMocks.put(LdapService.LDAP_PASSWORD, "stones");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "ou=users,l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "ou=groups,l=egypt");
+
+		setup("aziz@egypt", "light", "mondoshawan@egypt", "stones");
+		resultGroups = ldapService.getMembersOfGroup(mockedSite, LdapContextMock.MOCKED_GROUP_NAME);
+
+		// FIXME: This is not a valid comparison, but works as long as some assumptions remain stable.
+		Assert.assertEquals("[Subject#null_aziz, Subject#null_aziz' brother]", resultGroups.toString());
+	}
+
+	@Test
+	public void testLoginUserStartTls() throws NamingException, IOException {
+		boolean success;
+
+		// DN
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "DN");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_ID_ATTRIBUTE, "uid");
+		sitePropertyMocks.put(LdapService.LDAP_START_TLS, true);
+		setup("uid=aziz,l=egypt", "light", null, null);
+		success = ldapService.loginUser(mockedSite, "aziz", "light".toCharArray());
+		Assert.assertTrue(success);
 	}
 }


### PR DESCRIPTION
Hi madness-inc,

I have reworked the appNG LDAP implementation a bit, to make it compatible with OpenLDAP.

To achieve that, I introduced two new site-properties:
* **LDAP_PRINCIPAL_SCHEME** (_DN_, _UPN_, _SAM_): Controls how the appNG username is mapped to an LDAP principal.
* **LDAP_START_TLS** (_true_/_false_): Activates the StartTLS feature, which has been added.

Additionally the unit tests were changed, so that they do not have to extend  `LdapService` anymore. This made them dependent on private implementation details of the service before. They now use their own ContextFactory and they should have a better coverage.

When I get a go-ahead from your side, I will update the "Manager User Manual" to reflect the changes.

Best regards,
Dirk
