### PR TITLE
APPNG-2114 Changed LDAP user id matching to be case insensitive.

### DIFF
--- a/appng-core/src/main/java/org/appng/core/service/LdapService.java
+++ b/appng-core/src/main/java/org/appng/core/service/LdapService.java
@@ -272,7 +272,7 @@ public class LdapService {
 					Attributes userAttrs = ctx.getAttributes(member);
 					String id = (String) userAttrs.get(idAttribute).get();
 					String realName = (String) userAttrs.get(CN_ATTRIBUTE).get();
-					if (username.equals(id)) {
+					if (username.equalsIgnoreCase(id)) {
 						userGroups.add(group);
 						subject.setName(username);
 						subject.setRealname(realName);


### PR DESCRIPTION
Hi Matthias,

I changed the equals clause.
Members of ldap groups can be used in a case insensitive manner now.

Regards,
Dirk