### PR TITLE
APPNG-2122: Compatibility of unit tests with Mac OS X

### DIFF
--- a/appng-cli/src/test/java/org/appng/cli/commands/CommandBatchTest.java
+++ b/appng-cli/src/test/java/org/appng/cli/commands/CommandBatchTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.appng.tools.os.OperatingSystem;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -57,18 +58,27 @@ public class CommandBatchTest {
 
 	@Test
 	public void testSysEnvVariables() {
-		String osName = System.getProperty("os.name");
-		boolean isLinux = StringUtils.containsIgnoreCase(osName, "linux");
-		boolean isWindows = StringUtils.containsIgnoreCase(osName, "windows");
-		if (isLinux) {
+		OperatingSystem os = OperatingSystem.detect();
+
+		switch (os) {
+		case LINUX:
 			Set<String> validResults = new HashSet<String>(Arrays.asList("en_US.UTF-8", "de_DE.UTF-8"));
 			Assert.assertArrayEquals(new String[0], batch.parseLine("def LANG = ${systemEnv['LANG']}"));
 			Assert.assertTrue(validResults.contains(variables.get("LANG")));
-		} else if (isWindows) {
+			break;
+
+		case WINDOWS:
 			Assert.assertArrayEquals(new String[0], batch.parseLine("def SYSTEMROOT = ${systemEnv['SystemRoot']}"));
 			Assert.assertTrue(StringUtils.equalsIgnoreCase(variables.get("SYSTEMROOT"), "c:\\windows"));
-		} else {
-			Assert.fail("No test found for Operating System: " + osName);
+			break;
+
+		case MACOSX:
+			Assert.assertArrayEquals(new String[0], batch.parseLine("def HOME = ${systemEnv['HOME']}"));
+			Assert.assertTrue(StringUtils.containsIgnoreCase(variables.get("HOME"), "users"));
+			break;
+
+		case OTHER:
+			Assert.fail("Unsupported operating system found: " + os);
 		}
 	}
 

--- a/appng-core/src/test/java/org/appng/core/controller/RepositoryWatcherTest.java
+++ b/appng-core/src/test/java/org/appng/core/controller/RepositoryWatcherTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import org.apache.commons.io.FileUtils;
+import org.appng.tools.os.OperatingSystem;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -66,7 +67,13 @@ public class RepositoryWatcherTest {
 
 		FileUtils.touch(new File(rootDir, fehlerJsp));
 		FileUtils.touch(new File(rootDir, testJsp));
-		Thread.sleep(200);
+		if (OperatingSystem.isMac()) {
+			// APPNG-2122: It seems it takes much longer on a Mac until the watcher is notified, or OS X behaves
+			// differently than Linux or Windows.
+			Thread.sleep(20000);
+		} else {
+			Thread.sleep(200);
+		}
 		Assert.assertNull(ehcache.get(keyFehlerJsp));
 		Assert.assertNull(ehcache.get(keyTestJsp));
 		Assert.assertNull(ehcache.get("GET/de/error"));

--- a/appng-core/src/test/java/org/appng/core/controller/RepositoryWatcherTest.java
+++ b/appng-core/src/test/java/org/appng/core/controller/RepositoryWatcherTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import org.apache.commons.io.FileUtils;
-import org.appng.tools.os.OperatingSystem;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,7 +36,7 @@ import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
 
 public class RepositoryWatcherTest {
 
-	@Test
+	@Test(timeout = 20000)
 	public void test() throws Exception {
 		ClassLoader classLoader = RepositoryWatcherTest.class.getClassLoader();
 		String rootDir = classLoader.getResource("repository/manager/www").getFile();
@@ -67,12 +66,8 @@ public class RepositoryWatcherTest {
 
 		FileUtils.touch(new File(rootDir, fehlerJsp));
 		FileUtils.touch(new File(rootDir, testJsp));
-		if (OperatingSystem.isMac()) {
-			// APPNG-2122: It seems it takes much longer on a Mac until the watcher is notified, or OS X behaves
-			// differently than Linux or Windows.
-			Thread.sleep(20000);
-		} else {
-			Thread.sleep(200);
+		while (ehcache.getSize() != 0) {
+			Thread.sleep(100);
 		}
 		Assert.assertNull(ehcache.get(keyFehlerJsp));
 		Assert.assertNull(ehcache.get(keyTestJsp));

--- a/appng-tools/src/main/java/org/appng/tools/os/OperatingSystem.java
+++ b/appng-tools/src/main/java/org/appng/tools/os/OperatingSystem.java
@@ -15,6 +15,11 @@
  */
 package org.appng.tools.os;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Enum type for different operating systems.
  * 
@@ -23,15 +28,38 @@ package org.appng.tools.os;
  */
 public enum OperatingSystem {
 
-	LINUX, MAC, WINDOWS;
+	LINUX("linux", "nix"), WINDOWS("windows"), MACOSX("mac"), OTHER("");
+
+	private String[] searchString;
+	private static final List<OperatingSystem> operatingSystems = Arrays.asList(values());
+
+	private OperatingSystem(String... searchString) {
+		this.searchString = searchString;
+	}
 
 	/**
-	 * Checks if {@code System.getProperty("os.name")} returns a value that contains {@code "linux"} (ignoring case).
+	 * Detects the current operating system.
+	 *
+	 * @return The enum depicting the current operating system.
+	 */
+	public static OperatingSystem detect() {
+		return detect(System.getProperty("os.name"));
+	}
+
+	static OperatingSystem detect(String osName) {
+		String name = null != osName ? osName.toLowerCase() : "";
+		return operatingSystems.stream().filter(os -> StringUtils.containsAny(name, os.searchString)).findFirst()
+				.orElse(OTHER);
+	}
+
+	/**
+	 * Checks if {@code System.getProperty("os.name")} returns a value that contains {@code "linux"} or {@code "nix"}
+	 * (ignoring case).
 	 * 
 	 * @return {@code true} if this is the case, {@code false} otherwise
 	 */
 	public static boolean isLinux() {
-		return isOs(LINUX);
+		return LINUX.equals(detect());
 	}
 
 	/**
@@ -40,7 +68,7 @@ public enum OperatingSystem {
 	 * @return {@code true} if this is the case, {@code false} otherwise
 	 */
 	public static boolean isMac() {
-		return isOs(MAC);
+		return MACOSX.equals(detect());
 	}
 
 	/**
@@ -49,11 +77,21 @@ public enum OperatingSystem {
 	 * @return {@code true} if this is the case, {@code false} otherwise
 	 */
 	public static boolean isWindows() {
-		return isOs(WINDOWS);
+		return WINDOWS.equals(detect());
+	}
+
+	/**
+	 * Checks if {@code System.getProperty("os.name")} returns a value that does not match the other operating system
+	 * name patterns.
+	 *
+	 * @return {@code true} if this is the case, {@code false} otherwise
+	 */
+	public static boolean isOther() {
+		return OTHER.equals(detect());
 	}
 
 	static boolean isOs(OperatingSystem os) {
-		return System.getProperty("os.name").toLowerCase().contains(os.name().toLowerCase());
+		return os.equals(detect());
 	}
 
 }

--- a/appng-tools/src/test/java/org/appng/tools/os/OperatingSystemTest.java
+++ b/appng-tools/src/test/java/org/appng/tools/os/OperatingSystemTest.java
@@ -19,31 +19,31 @@ public class OperatingSystemTest {
 		OperatingSystem os = OperatingSystem.detect();
 		if (OperatingSystem.isLinux()) {
 			Assert.assertEquals(OperatingSystem.LINUX, os);
-			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.LINUX));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.WINDOWS));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.MACOSX));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.OTHER));
+			Assert.assertTrue(OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.OTHER));
 		}
 		if (OperatingSystem.isWindows()) {
 			Assert.assertEquals(OperatingSystem.WINDOWS, os);
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.LINUX));
-			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.WINDOWS));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.MACOSX));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.OTHER));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertTrue(OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.OTHER));
 		}
 		if (OperatingSystem.isMac()) {
 			Assert.assertEquals(OperatingSystem.MACOSX, os);
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.LINUX));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.WINDOWS));
-			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.MACOSX));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.OTHER));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertTrue(OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.OTHER));
 		}
 		if (OperatingSystem.isOther()) {
 			Assert.assertEquals(OperatingSystem.OTHER, os);
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.LINUX));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.WINDOWS));
-			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.MACOSX));
-			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.OTHER));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertFalse(OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertTrue(OperatingSystem.isOs(OperatingSystem.OTHER));
 		}
 	}
 

--- a/appng-tools/src/test/java/org/appng/tools/os/OperatingSystemTest.java
+++ b/appng-tools/src/test/java/org/appng/tools/os/OperatingSystemTest.java
@@ -1,0 +1,50 @@
+package org.appng.tools.os;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OperatingSystemTest {
+
+	@Test
+	public void testOsDetection() {
+		Assert.assertEquals(OperatingSystem.LINUX, OperatingSystem.detect("Debian GNU/Linux Stretch"));
+		Assert.assertEquals(OperatingSystem.LINUX, OperatingSystem.detect("Unix"));
+		Assert.assertEquals(OperatingSystem.LINUX, OperatingSystem.detect("Minix"));
+		Assert.assertEquals(OperatingSystem.WINDOWS, OperatingSystem.detect("Microsoft Windows Server 2016"));
+		Assert.assertEquals(OperatingSystem.MACOSX, OperatingSystem.detect("Mac OS X"));
+		Assert.assertEquals(OperatingSystem.OTHER, OperatingSystem.detect("MS DOS 5.0"));
+		Assert.assertEquals(OperatingSystem.OTHER, OperatingSystem.detect(""));
+		Assert.assertEquals(OperatingSystem.OTHER, OperatingSystem.detect(null));
+
+		OperatingSystem os = OperatingSystem.detect();
+		if (OperatingSystem.isLinux()) {
+			Assert.assertEquals(OperatingSystem.LINUX, os);
+			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.OTHER));
+		}
+		if (OperatingSystem.isWindows()) {
+			Assert.assertEquals(OperatingSystem.WINDOWS, os);
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.OTHER));
+		}
+		if (OperatingSystem.isMac()) {
+			Assert.assertEquals(OperatingSystem.MACOSX, os);
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.OTHER));
+		}
+		if (OperatingSystem.isOther()) {
+			Assert.assertEquals(OperatingSystem.OTHER, os);
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.LINUX));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.WINDOWS));
+			Assert.assertEquals(false, OperatingSystem.isOs(OperatingSystem.MACOSX));
+			Assert.assertEquals(true, OperatingSystem.isOs(OperatingSystem.OTHER));
+		}
+	}
+
+}


### PR DESCRIPTION
- RepositoryWatcherTest failed, because we expect the RepositoryWatcher
  to receive the events ENTRY_DELETE and ENTRY_MODIFY within less than
  200ms. On Mac OS X this seems to take much longer. Even 10s was not
  enough, we are waiting now 20s until the thread proceeds.
- The improved operating system detection now allows to just detect and
  return the current operating system, which is handy for switch/case
  statements. Furthermore, it is now possible to define multiple search
  strings which result in the detection of the same (appNG-internal)
  operating system type. This is useful, if e.g. different Linux/Unix
  flavors return different values for os.name.
- CommandBatchTest has been updated to include a Mac OS X-specific test.