### PR TITLE
APPNG-2230/2231 new CLI command for pre-hasing passwords

### DIFF
--- a/appng-cli/src/main/java/org/appng/cli/CliCore.java
+++ b/appng-cli/src/main/java/org/appng/cli/CliCore.java
@@ -53,6 +53,7 @@ import org.appng.cli.commands.site.ReloadSite;
 import org.appng.cli.commands.site.SetSiteActive;
 import org.appng.cli.commands.subject.CreateSubject;
 import org.appng.cli.commands.subject.DeleteSubject;
+import org.appng.cli.commands.subject.HashPassword;
 import org.appng.cli.commands.subject.ListSubjects;
 import org.appng.cli.commands.template.DeleteTemplate;
 import org.appng.cli.commands.template.InstallTemplate;
@@ -128,6 +129,7 @@ public class CliCore {
 
 		commands.add("list-subjects", new ListSubjects());
 		commands.add("create-subject", new CreateSubject());
+		commands.add("hash-pw", new HashPassword());
 		commands.add("delete-subject", new DeleteSubject());
 
 		commands.add("install-template", new InstallTemplate());

--- a/appng-cli/src/main/java/org/appng/cli/commands/subject/HashPassword.java
+++ b/appng-cli/src/main/java/org/appng/cli/commands/subject/HashPassword.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.appng.cli.commands.subject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+import org.appng.api.BusinessException;
+import org.appng.api.Platform;
+import org.appng.api.model.AuthSubject;
+import org.appng.cli.CliEnvironment;
+import org.appng.cli.ExecutableCliCommand;
+import org.appng.core.security.DefaultPasswordPolicy;
+import org.appng.core.security.PasswordHandler;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+/**
+ * Hashes a password using the platform's default {@link PasswordHandler}.
+ * 
+ * <pre>
+ * Usage: hash-pw [options] <cleartext-password>
+ *   Options:
+ *   -i
+ *        Enables interactive mode.
+ *        Default: false
+ * </pre>
+ * 
+ * @author Matthias Müller
+ */
+@Parameters(commandDescription = "Hashes a password.")
+public class HashPassword implements ExecutableCliCommand {
+
+	@Parameter(required = false, description = "<cleartext-password>")
+	private String password;
+
+	@Parameter(names = "-i", required = false, description = "Enables interactive mode.")
+	private boolean interactive = false;
+
+	public HashPassword() {
+
+	}
+
+	HashPassword(String password) {
+		this.password = password;
+	}
+
+	HashPassword(boolean interactive) {
+		this.interactive = interactive;
+	}
+
+	public void execute(CliEnvironment cle) throws BusinessException {
+		boolean passwordSet = StringUtils.isNotBlank(password);
+		if (!(interactive || passwordSet)) {
+			throw new BusinessException("Either password must be given or -i must be set!");
+		}
+		if (interactive) {
+			runInteractive(cle);
+			return;
+		}
+		String digest = savePasswordForSubject(cle, new PasswordSubject(), password);
+		cle.setResult(digest);
+	}
+
+	private void runInteractive(CliEnvironment cle) throws BusinessException {
+		try (BufferedReader console = new BufferedReader(new InputStreamReader(System.in));) {
+			try {
+				CliEnvironment.out.println("Hashes a password. Type CTRL + C to quit.");
+				while (true) {
+					try {
+						CliEnvironment.out.print("password: ");
+						String commandLine = console.readLine();
+						if (null != StringUtils.trimToNull(commandLine)) {
+							String digest = savePasswordForSubject(cle, new PasswordSubject(), commandLine);
+							CliEnvironment.out.print("hash: ");
+							CliEnvironment.out.println(digest);
+						}
+					} catch (BusinessException e) {
+						CliEnvironment.out.println(e.getMessage());
+					}
+					continue;
+				}
+			} catch (IOException e) {
+				throw new BusinessException(e);
+			}
+		} catch (IOException e1) {
+			throw new BusinessException(e1);
+		}
+	}
+
+	static String savePasswordForSubject(CliEnvironment cle, AuthSubject subject, String password)
+			throws BusinessException {
+		String regEx = cle.getPlatformConfig().getString(Platform.Property.PASSWORD_POLICY_REGEX);
+		String errorMessageKey = cle.getPlatformConfig().getString(Platform.Property.PASSWORD_POLICY_ERROR_MSSG_KEY);
+
+		if (!new DefaultPasswordPolicy(regEx, errorMessageKey).isValidPassword(password.toCharArray())) {
+			String errorMessage = cle.getMessageSource().getMessage(errorMessageKey, null, Locale.ENGLISH);
+			throw new BusinessException(errorMessage);
+		}
+		PasswordHandler passwordHandler = cle.getCoreService().getDefaultPasswordHandler(subject);
+		passwordHandler.savePassword(password);
+		return subject.getDigest();
+	}
+
+	static class PasswordSubject implements AuthSubject {
+
+		private String digest;
+
+		public String getDigest() {
+			return digest;
+		}
+
+		public void setDigest(String digest) {
+			this.digest = digest;
+		}
+
+		// dummy methods
+		public String getAuthName() {
+			return null;
+		}
+
+		public String getRealname() {
+			return null;
+		}
+
+		public String getLanguage() {
+			return null;
+		}
+
+		public String getTimeZone() {
+			return null;
+		}
+
+		public String getEmail() {
+			return null;
+		}
+
+		public String getSalt() {
+			return null;
+		}
+
+		public void setSalt(String salt) {
+		}
+
+	}
+}

--- a/appng-cli/src/test/java/org/appng/cli/commands/subject/CommandCreateSubjectTest.java
+++ b/appng-cli/src/test/java/org/appng/cli/commands/subject/CommandCreateSubjectTest.java
@@ -47,14 +47,24 @@ public class CommandCreateSubjectTest extends AbstractCommandTest {
 	@Test
 	@Override
 	public void test() throws BusinessException {
-		new CreateSubject(authName, realName, email, password, language, description, type).execute(cliEnv);
+		new CreateSubject(authName, realName, email, password, language, description, type, false).execute(cliEnv);
+		validate();
+	}
+
+	@Test
+	public void testPasswordHashed() throws BusinessException {
+		email = "pass@word.com";
+		authName = "preHashedPassword";
+		new CreateSubject(authName, realName, email, "$2a$13$qCikwbm6MpoQVcNr0Q66sufn1boqx7AErXAucGeuprSmW/gME3qIG",
+				language, description, type, true).execute(cliEnv);
 		validate();
 	}
 
 	@Test
 	public void testInvalidPassword() {
 		try {
-			new CreateSubject("anotheruser", realName, email, "test", language, description, type).execute(cliEnv);
+			new CreateSubject("anotheruser", realName, email, "test", language, description, type, false)
+					.execute(cliEnv);
 			fail("Must throw BusinessException!");
 		} catch (BusinessException e) {
 			assertEquals("The password should be built up of 6 to 64 characters and must not contain spaces.",
@@ -65,7 +75,7 @@ public class CommandCreateSubjectTest extends AbstractCommandTest {
 	@Test
 	public void testLocalNoPassword() {
 		try {
-			new CreateSubject("anotheruser", realName, email, null, language, description, type).execute(cliEnv);
+			new CreateSubject("anotheruser", realName, email, null, language, description, type, false).execute(cliEnv);
 			fail("Must throw BusinessException!");
 		} catch (BusinessException e) {
 			assertEquals("-p is mandatory for type LOCAL_USER", e.getMessage());
@@ -77,14 +87,14 @@ public class CommandCreateSubjectTest extends AbstractCommandTest {
 		authName = "adminFromLdap";
 		email = "adldap@min.com";
 		type = UserType.GLOBAL_GROUP;
-		new CreateSubject(authName, realName, email, null, language, description, type).execute(cliEnv);
+		new CreateSubject(authName, realName, email, null, language, description, type, false).execute(cliEnv);
 		validate();
 	}
 
 	@Test
 	public void testGroupWithPassword() throws BusinessException {
 		try {
-			new CreateSubject(authName, realName, email, password, language, description, UserType.GLOBAL_GROUP)
+			new CreateSubject(authName, realName, email, password, language, description, UserType.GLOBAL_GROUP, false)
 					.execute(cliEnv);
 			fail("Must throw BusinessException!");
 		} catch (BusinessException e) {
@@ -95,7 +105,7 @@ public class CommandCreateSubjectTest extends AbstractCommandTest {
 	@Test
 	public void testUserExists() {
 		try {
-			new CreateSubject(authName, realName, email, password, language, description, type).execute(cliEnv);
+			new CreateSubject(authName, realName, email, password, language, description, type, false).execute(cliEnv);
 			fail("Must throw BusinessException!");
 		} catch (BusinessException e) {
 			assertEquals("Subject with name 'admin' already exists.", e.getMessage());

--- a/appng-cli/src/test/java/org/appng/cli/commands/subject/HashPasswordTest.java
+++ b/appng-cli/src/test/java/org/appng/cli/commands/subject/HashPasswordTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.appng.cli.commands.subject;
+
+import org.appng.api.BusinessException;
+import org.appng.cli.commands.AbstractCommandTest;
+import org.appng.cli.commands.subject.HashPassword.PasswordSubject;
+import org.appng.core.security.BCryptPasswordHandler;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class HashPasswordTest extends AbstractCommandTest {
+
+	private static final String SUPERSECRET = "supersecret";
+
+	public HashPassword getCommand() {
+		return new HashPassword(SUPERSECRET);
+	}
+
+	public void validate() {
+		PasswordSubject authSubject = new PasswordSubject();
+		authSubject.setDigest(cliEnv.getResult());
+		BCryptPasswordHandler passwordHandler = new BCryptPasswordHandler(authSubject);
+		passwordHandler.isValidPassword(SUPERSECRET);
+	}
+	
+	@Test
+	public void testInteractive() throws BusinessException{
+		new HashPassword(true).execute(cliEnv);
+	}
+
+}

--- a/appng-cli/src/test/java/org/appng/cli/commands/subject/HashPasswordTest.java
+++ b/appng-cli/src/test/java/org/appng/cli/commands/subject/HashPasswordTest.java
@@ -20,7 +20,7 @@ import org.appng.cli.commands.AbstractCommandTest;
 import org.appng.cli.commands.subject.HashPassword.PasswordSubject;
 import org.appng.core.security.BCryptPasswordHandler;
 import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -39,7 +39,7 @@ public class HashPasswordTest extends AbstractCommandTest {
 		passwordHandler.isValidPassword(SUPERSECRET);
 	}
 	
-	@Test
+	@Ignore("only for local usage")
 	public void testInteractive() throws BusinessException{
 		new HashPassword(true).execute(cliEnv);
 	}


### PR DESCRIPTION
- support new CLI command `hash-pw`, including also an interactive mode
- added an option `-h` to command `create-subject` to indicate the password has already been hashed
