### PR TITLE
APPNG-2264 reworked internal session tracking

### DIFF
--- a/appng-core/src/main/java/org/appng/core/controller/Controller.java
+++ b/appng-core/src/main/java/org/appng/core/controller/Controller.java
@@ -82,11 +82,6 @@ public class Controller extends DefaultServlet implements ContainerServlet {
 	private static final String SCHEME_HTTPS = "https://";
 	private static final String SCHEME_HTTP = "http://";
 
-	/**
-	 * A string flag to be set in the {@link Environment} with {@link Scope#SESSION}, indicating that
-	 * {@link #expireSessions(Environment, Site)} should be called
-	 */
-	public static final String EXPIRE_SESSIONS = "expireSessions";
 	protected static final String SESSION_MANAGER = "sessionManager";
 
 	protected JspHandler jspHandler;
@@ -312,8 +307,8 @@ public class Controller extends DefaultServlet implements ContainerServlet {
 		context.setSessionTimeout((int) TimeUnit.SECONDS.toMinutes(sessionTimeout));
 	}
 
-	protected void expireSessions(Environment env,Site site) {
-		SessionListener.expire(manager, env, env.removeAttribute(SESSION, EXPIRE_SESSIONS), site);
+	protected void expireSessions(Environment env, Site site) {
+		SessionListener.expire(manager, env, site);
 	}
 
 	public JspHandler getJspHandler() {

--- a/appng-core/src/main/java/org/appng/core/controller/Controller.java
+++ b/appng-core/src/main/java/org/appng/core/controller/Controller.java
@@ -21,7 +21,6 @@ import static org.appng.api.Scope.SESSION;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.Servlet;
@@ -84,10 +83,11 @@ public class Controller extends DefaultServlet implements ContainerServlet {
 	private static final String SCHEME_HTTP = "http://";
 
 	/**
-	 * a boolean flag to be set in the {@link Environment} with {@link Scope#SESSION}, indicating that
-	 * {@link #expireSessions(HttpServletRequest, Environment, Site)} should be called
+	 * A string flag to be set in the {@link Environment} with {@link Scope#SESSION}, indicating that
+	 * {@link #expireSessions(Environment, Site)} should be called
 	 */
 	public static final String EXPIRE_SESSIONS = "expireSessions";
+	protected static final String SESSION_MANAGER = "sessionManager";
 
 	protected JspHandler jspHandler;
 
@@ -177,7 +177,7 @@ public class Controller extends DefaultServlet implements ContainerServlet {
 		Properties platformProperties = env.getAttribute(Scope.PLATFORM, Platform.Environment.PLATFORM_CONFIG);
 		Boolean allowPlainRequests = platformProperties.getBoolean(ALLOW_PLAIN_REQUESTS, true);
 
-		expireSessions(servletRequest, env, site);
+		expireSessions(env, site);
 
 		if (site != null) {
 			try {
@@ -304,44 +304,20 @@ public class Controller extends DefaultServlet implements ContainerServlet {
 
 	public void setWrapper(Wrapper wrapper) {
 		Context context = ((Context) wrapper.getParent());
+		this.manager = context.getManager();
+		context.getServletContext().setAttribute(SESSION_MANAGER, manager);
 		Environment env = DefaultEnvironment.get(context.getServletContext());
 		Properties platformConfig = env.getAttribute(Scope.PLATFORM, Platform.Environment.PLATFORM_CONFIG);
 		Integer sessionTimeout = platformConfig.getInteger(Platform.Property.SESSION_TIMEOUT);
 		context.setSessionTimeout((int) TimeUnit.SECONDS.toMinutes(sessionTimeout));
-		this.manager = context.getManager();
 	}
 
-	protected void expireSessions(HttpServletRequest servletRequest, Environment env, Site site) {
-		if (null != manager && Boolean.TRUE.equals(env.removeAttribute(SESSION, EXPIRE_SESSIONS))) {
-			List<org.appng.core.controller.Session> sessions = env.getAttribute(Scope.PLATFORM,
-					SessionListener.SESSIONS);
-			for (org.appng.core.controller.Session session : sessions) {
-				org.apache.catalina.Session containerSession = getContainerSession(session.getId());
-				if (null != containerSession) {
-					if (session.isExpired()) {
-						LOGGER.info("expiring session {}", session.getId());
-						containerSession.expire();
-					}
-				} else {
-					LOGGER.debug("session to expire not found in {}: {} (created: {}, last access: {})",
-							manager.getClass().getSimpleName(), session.getId(), session.getCreationTime(),
-							session.getLastAccessedTime());
-					SessionListener.destroySession(session.getId(), env);
-				}
-			}
-		}
-	}
-
-	private org.apache.catalina.Session getContainerSession(String sessionId) {
-		try {
-			return manager.findSession(sessionId);
-		} catch (IOException e) {
-			LOGGER.warn(String.format("error while retrieving session %s", sessionId), e);
-		}
-		return null;
+	protected void expireSessions(Environment env,Site site) {
+		SessionListener.expire(manager, env, env.removeAttribute(SESSION, EXPIRE_SESSIONS), site);
 	}
 
 	public JspHandler getJspHandler() {
 		return jspHandler;
 	}
+
 }

--- a/appng-core/src/main/java/org/appng/core/controller/ExpireSessionEvent.java
+++ b/appng-core/src/main/java/org/appng/core/controller/ExpireSessionEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.appng.core.controller;
+
+import javax.servlet.ServletContext;
+
+import org.apache.catalina.Manager;
+import org.apache.catalina.session.StandardManager;
+import org.appng.api.BusinessException;
+import org.appng.api.Environment;
+import org.appng.api.InvalidConfigurationException;
+import org.appng.api.messaging.Event;
+import org.appng.api.model.Site;
+import org.appng.api.support.environment.DefaultEnvironment;
+
+/**
+ * Event needed to expire a session in a sticky session scenario when Tomcat's {@link StandardManager} is being used.
+ */
+class ExpireSessionEvent extends Event {
+	private static final long serialVersionUID = 1L;
+	private final String sessionId;
+
+	public ExpireSessionEvent(String siteName, String sessionId) {
+		super(siteName);
+		this.sessionId = sessionId;
+	}
+
+	public void perform(Environment env, Site site) throws InvalidConfigurationException, BusinessException {
+		ServletContext servletContext = ((DefaultEnvironment) env).getServletContext();
+		Manager manager = (Manager) servletContext.getAttribute(Controller.SESSION_MANAGER);
+		SessionListener.expire(manager, env, sessionId, site);
+	}
+
+}

--- a/appng-core/src/main/java/org/appng/core/controller/Session.java
+++ b/appng-core/src/main/java/org/appng/core/controller/Session.java
@@ -15,15 +15,19 @@
  */
 package org.appng.core.controller;
 
+import java.io.Serializable;
 import java.util.Date;
 
 /**
  * A simple value object representing a users's http-session.
  * 
  * @author Matthias Müller
+ * 
+ * @see SessionListener
  */
-public class Session implements Cloneable {
+public class Session implements Cloneable, Serializable {
 
+	private static final long serialVersionUID = 1L;
 	private String id;
 	private String domain;
 	private String site;

--- a/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
+++ b/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
@@ -50,7 +50,6 @@ import org.springframework.context.ApplicationContext;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
-import net.sf.ehcache.config.PersistenceConfiguration.Strategy;
 
 /**
  * A (ServletContext/HttpSession/ServletRequest) listener that keeps track of
@@ -84,13 +83,9 @@ public class SessionListener implements ServletContextListener, HttpSessionListe
 	private static final FastDateFormat DATE_PATTERN = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
 
 	public void contextInitialized(ServletContextEvent sce) {
-		CacheService.getCacheManager().addCache(SESSIONS);
-		Cache cache = CacheService.getCacheManager().getCache(SESSIONS);
-		cache.getCacheConfiguration().setTimeToIdleSeconds(0);
-		cache.getCacheConfiguration().setTimeToLiveSeconds(0);
-		cache.getCacheConfiguration().eternal(true);
-		cache.getCacheConfiguration().getPersistenceConfiguration().setStrategy(Strategy.NONE.name());
-		LOGGER.info("Created eternal cache '{}'.", SESSIONS);
+		Cache cache = new Cache(SESSIONS, 1000000, false, true, 0, 0);
+		LOGGER.info("Created eternal cache '{}'.", cache.getName());
+		CacheService.getCacheManager().addCache(cache);
 	}
 
 	public void contextDestroyed(ServletContextEvent sce) {

--- a/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
+++ b/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
@@ -72,7 +72,7 @@ public class SessionListener implements ServletContextListener, HttpSessionListe
 	/**
 	 * A string flag to be set in the {@link Environment} with
 	 * {@link Scope#SESSION}, indicating that
-	 * {@link #expireSessions(Environment, Site)} should be called.
+	 * {@link #expire(Manager, Environment, Site)} should be called.
 	 */
 	public static final String EXPIRE_SESSIONS = "expireSessions";
 

--- a/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
+++ b/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
@@ -255,7 +255,7 @@ public class SessionListener implements ServletContextListener, HttpSessionListe
 	static void expire(Manager manager, Environment env, String sessionId, Site site) {
 		if (ALL.equals(sessionId)) {
 			getSessions().parallelStream().forEach(session -> expireSession(manager, env, session, site));
-		} else {
+		} else if (null != sessionId) {
 			expireSession(manager, env, getSession(sessionId), site);
 		}
 	}

--- a/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
+++ b/appng-core/src/main/java/org/appng/core/controller/SessionListener.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpSessionListener;
 
 import org.apache.catalina.Manager;
 import org.apache.catalina.session.StandardManager;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.appng.api.Environment;
 import org.appng.api.Platform;
@@ -239,7 +240,9 @@ public class SessionListener implements ServletContextListener, HttpSessionListe
 	 */
 	public static List<Session> getSessions() {
 		Cache sessionCache = getSessionCache();
-		return sessionCache.getAll(sessionCache.getKeys()).values().stream().map(e -> (Session) e.getObjectValue())
+		return sessionCache.getAll(sessionCache.getKeys()).values().parallelStream()
+				.map(e -> (Session) e.getObjectValue())
+				.sorted((s1, s2) -> ObjectUtils.compare(s1.getCreationTime(), s2.getCreationTime()))
 				.collect(Collectors.toList());
 	}
 

--- a/appng-core/src/test/java/org/appng/core/controller/SessionListenerTest.java
+++ b/appng-core/src/test/java/org/appng/core/controller/SessionListenerTest.java
@@ -31,27 +31,32 @@ import org.appng.api.Scope;
 import org.appng.api.VHostMode;
 import org.appng.api.model.Properties;
 import org.appng.api.model.Site;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockServletContext;
 
+import net.sf.ehcache.Status;
+
 public class SessionListenerTest {
 
-	private ServletContext servletContext = new MockServletContext();
+	private static ServletContext servletContext = new MockServletContext();
 	private MockHttpSession session1 = new MockHttpSession(servletContext, "ZUS383883OTOTOLSKKL");
 	private MockHttpSession session2 = new MockHttpSession(servletContext, "ERTERTZGFHFGHGFH234");
-	private Map<String, Object> platformMap;
+	private static Map<String, Object> platformMap;
 
-	private SessionListener sessionListener;
+	private static SessionListener sessionListener;
 
-	@Before
-	public void setup() {
+	@BeforeClass
+	public static void setup() {
 		sessionListener = new SessionListener();
+		sessionListener.contextInitialized(new ServletContextEvent(servletContext));
+		Assert.assertEquals(Status.STATUS_ALIVE, SessionListener.getSessionCache().getStatus());
+
 		platformMap = new ConcurrentHashMap<>();
 		Properties props = Mockito.mock(Properties.class);
 		Mockito.when(props.getString(Platform.Property.VHOST_MODE)).thenReturn(VHostMode.NAME_BASED.name());
@@ -64,14 +69,13 @@ public class SessionListenerTest {
 		sitemap.put(site.getHost(), site);
 		platformMap.put(Platform.Environment.SITES, sitemap);
 		servletContext.setAttribute(Scope.PLATFORM.name(), platformMap);
-		sessionListener.contextInitialized(new ServletContextEvent(servletContext));
 	}
 
-	@After
-	public void tearDown() {
-		Assert.assertNotNull(platformMap.get(SessionListener.SESSIONS));
+	@AfterClass
+	public static void tearDown() {
+		Assert.assertNotNull(SessionListener.getSessions());
 		sessionListener.contextDestroyed(new ServletContextEvent(servletContext));
-		Assert.assertNull(platformMap.get(SessionListener.SESSIONS));
+		Assert.assertEquals(Status.STATUS_SHUTDOWN, SessionListener.getSessionCache().getStatus());
 	}
 
 	@Test
@@ -100,9 +104,7 @@ public class SessionListenerTest {
 		sessionListener.requestInitialized(requestEvent);
 	}
 
-	@SuppressWarnings("unchecked")
 	private List<Session> getSessions() {
-		Map<String, Object> platformMap = (Map<String, Object>) servletContext.getAttribute(Scope.PLATFORM.name());
-		return (List<Session>) platformMap.get(SessionListener.SESSIONS);
+		return SessionListener.getSessions();
 	}
 }


### PR DESCRIPTION
- using an eternal ehcache instead of a platform-scoped map
- also supports sticky session scenarios where tomcats standardmanager is used