### PR TITLE
Feature/appng 2329

### DIFF
--- a/appng-api/src/main/resources/messages-core.properties
+++ b/appng-api/src/main/resources/messages-core.properties
@@ -69,6 +69,7 @@ ConfigurablePasswordPolicy.TOO_LONG=Password  must be at most {0} characters lon
 ConfigurablePasswordPolicy.TOO_SHORT=Password must be at least {0} characters long.
 
 validation.username = The name must either be a valid e-mail address, or consist of letters, digits, dots, underscores and hyphens
+validation.usernameGroup = The name must either be a valid e-mail address, or consist of letters, digits, dots, underscores and hyphens or a valid ldap group reference 
 validation.host = Please enter a valid host (examples: localhost example.com some.example.com)
 validation.domain = Please enter a valid domain (examples: http://www.example.com example.com localhost:8080)
 validation.name = Please enter a valid name, which may only consist of letters, numbers, spaces, dots, underscores and hyphens

--- a/appng-api/src/main/resources/messages-core.properties
+++ b/appng-api/src/main/resources/messages-core.properties
@@ -69,7 +69,7 @@ ConfigurablePasswordPolicy.TOO_LONG=Password  must be at most {0} characters lon
 ConfigurablePasswordPolicy.TOO_SHORT=Password must be at least {0} characters long.
 
 validation.username = The name must either be a valid e-mail address, or consist of letters, digits, dots, underscores and hyphens
-validation.usernameGroup = The name must either be a valid e-mail address, or consist of letters, digits, dots, underscores and hyphens or a valid ldap group reference 
+validation.usernameGroup = The name must either be a valid e-mail address, or consist of letters, digits, dots, underscores and hyphens or a valid LDAP group reference 
 validation.host = Please enter a valid host (examples: localhost example.com some.example.com)
 validation.domain = Please enter a valid domain (examples: http://www.example.com example.com localhost:8080)
 validation.name = Please enter a valid name, which may only consist of letters, numbers, spaces, dots, underscores and hyphens

--- a/appng-api/src/main/resources/messages-core_de.properties
+++ b/appng-api/src/main/resources/messages-core_de.properties
@@ -69,6 +69,7 @@ ConfigurablePasswordPolicy.TOO_LONG=Passwort darf höchstens {0} Zeichen lang se
 ConfigurablePasswordPolicy.TOO_SHORT=Passwort muss mindestens {0} Zeichen lang sein.
 
 validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen.
+validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen oder eine gültoge LDAP Gruppen-Referenz sein.
 validation.host = Bitte einen gültigen Host eingeben (Beispiele: localhost example.com some.example.com)
 validation.domain = Bitte eine gültige Domäne eingeben (Beispiele: http://www.example.com example.com  localhost:8080)
 validation.name = Bitte einen gültigen Namen eingeben, der nur aus Buchstaben, Zahlen, Leerzeichen, Punkten sowie Unter- und Bindestrichen besteht.

--- a/appng-api/src/main/resources/messages-core_de.properties
+++ b/appng-api/src/main/resources/messages-core_de.properties
@@ -69,7 +69,7 @@ ConfigurablePasswordPolicy.TOO_LONG=Passwort darf höchstens {0} Zeichen lang se
 ConfigurablePasswordPolicy.TOO_SHORT=Passwort muss mindestens {0} Zeichen lang sein.
 
 validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen.
-validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen oder eine gültoge LDAP Gruppen-Referenz sein.
+validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen oder eine gültige LDAP Gruppen-Referenz sein.
 validation.host = Bitte einen gültigen Host eingeben (Beispiele: localhost example.com some.example.com)
 validation.domain = Bitte eine gültige Domäne eingeben (Beispiele: http://www.example.com example.com  localhost:8080)
 validation.name = Bitte einen gültigen Namen eingeben, der nur aus Buchstaben, Zahlen, Leerzeichen, Punkten sowie Unter- und Bindestrichen besteht.

--- a/appng-api/src/main/resources/messages-core_de.properties
+++ b/appng-api/src/main/resources/messages-core_de.properties
@@ -69,7 +69,7 @@ ConfigurablePasswordPolicy.TOO_LONG=Passwort darf höchstens {0} Zeichen lang se
 ConfigurablePasswordPolicy.TOO_SHORT=Passwort muss mindestens {0} Zeichen lang sein.
 
 validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen.
-validation.username = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen oder eine gültige LDAP Gruppen-Referenz sein.
+validation.usernameGroup = Der Name muss entweder eine gültige E-Mail Adresse sein, oder aus Buchstaben, Zahlen, Punkten sowie Binde- und Unterstrichen bestehen oder eine gültige LDAP Gruppen-Referenz sein.
 validation.host = Bitte einen gültigen Host eingeben (Beispiele: localhost example.com some.example.com)
 validation.domain = Bitte eine gültige Domäne eingeben (Beispiele: http://www.example.com example.com  localhost:8080)
 validation.name = Bitte einen gültigen Namen eingeben, der nur aus Buchstaben, Zahlen, Leerzeichen, Punkten sowie Unter- und Bindestrichen besteht.

--- a/appng-core/pom.xml
+++ b/appng-core/pom.xml
@@ -374,6 +374,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.ldap</groupId>
+			<artifactId>spring-ldap-ldif-core</artifactId>
+			<version>2.3.2.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.rabbitmq</groupId>
 			<artifactId>amqp-client</artifactId>
 			<version>5.8.0</version>
@@ -425,7 +431,7 @@
 			<groupId>org.passay</groupId>
 			<artifactId>passay</artifactId>
 			<version>1.5.0</version>
-		</dependency>
+		</dependency>		
 	</dependencies>
 	<!-- END DEPENDENCY MANAGEMENT -->
 </project>

--- a/appng-core/src/main/java/org/appng/core/domain/SubjectImpl.java
+++ b/appng-core/src/main/java/org/appng/core/domain/SubjectImpl.java
@@ -82,8 +82,8 @@ public class SubjectImpl implements Subject, Auditable<Integer> {
 	private Date expiryDate;
 
 	@NotNull(message = ValidationMessages.VALIDATION_NOT_NULL)
-	@Pattern(regexp = ValidationPatterns.USERNAME_PATTERN, message = ValidationPatterns.USERNAME_MSSG)
-	@Size(max = ValidationPatterns.LENGTH_64, message = ValidationMessages.VALIDATION_STRING_MAX)
+	@Pattern(regexp = ValidationPatterns.USERNAME_OR_LDAPGROUP_PATTERN, message = ValidationPatterns.USERNAME_GROUP_MSSG)
+	@Size(max = ValidationPatterns.LENGTH_255, message = ValidationMessages.VALIDATION_STRING_MAX)
 	@Column(unique = true)
 	public String getName() {
 		return name;

--- a/appng-core/src/main/java/org/appng/core/domain/ValidationPatterns.java
+++ b/appng-core/src/main/java/org/appng/core/domain/ValidationPatterns.java
@@ -32,16 +32,19 @@ public class ValidationPatterns {
 	public static final String EMAIL_PATTERN = "^([a-zA-Z0-9_\\.-])+@(([a-zA-Z0-9-])+\\.)+([a-zA-Z0-9]){2,}$";
 	// may be either a word or an e-mail address
 	public static final String USERNAME_PATTERN = "^([a-zA-Z0-9_\\.-])+(@(([a-zA-Z0-9-])+\\.)+([a-zA-Z0-9]){2,})?$";
-
+	// may be either a word or an e-mail address or a ldap group definition with base dn
+	public static final String USERNAME_OR_LDAPGROUP_PATTERN = "^((((CN|cn)=[^,]+),?)*(((OU|ou)=[^,]+),?)*(((DC|dc)=[^,]+),?)*)|(([a-zA-Z0-9_\\.-])+(@(([a-zA-Z0-9-])+\\.)+([a-zA-Z0-9]){2,})?)$";
 	public static final String NAME_MSSG = "{validation.name}";
 	public static final String NAME_STRICT_MSSG = "{validation.nameStrict}";
 	public static final String PERMISSON_MSSG = "{validation.permission}";
 	public static final String HOST_MSSG = "{validation.host}";
 	public static final String DOMAIN_MSSG = "{validation.domain}";
 	public static final String USERNAME_MSSG = "{validation.username}";
+	public static final String USERNAME_GROUP_MSSG = "{validation.usernameGroup}";
 
 	public static final int LENGTH_8192 = 8192;
 	public static final int LENGTH_64 = 64;
+	public static final int LENGTH_255 = 255;
 
 	private ValidationPatterns() {
 	}

--- a/appng-core/src/main/resources/db/migration/hsql/V4_2_1__change_subject_name_length.sql
+++ b/appng-core/src/main/resources/db/migration/hsql/V4_2_1__change_subject_name_length.sql
@@ -1,0 +1,1 @@
+alter table subject change name varchar(255) not null;

--- a/appng-core/src/main/resources/db/migration/mssql/V4_2_1__change_subject_name_length.sql
+++ b/appng-core/src/main/resources/db/migration/mssql/V4_2_1__change_subject_name_length.sql
@@ -1,0 +1,1 @@
+alter table subject alter column name nvarchar(255);

--- a/appng-core/src/main/resources/db/migration/mysql/V4_2_1__change_subject_name_length.sql
+++ b/appng-core/src/main/resources/db/migration/mysql/V4_2_1__change_subject_name_length.sql
@@ -1,0 +1,1 @@
+alter table subject modify name varchar(255) not null unique;

--- a/appng-core/src/main/resources/db/migration/postgresql/V4_2_1__change_subject_name_length.sql
+++ b/appng-core/src/main/resources/db/migration/postgresql/V4_2_1__change_subject_name_length.sql
@@ -1,0 +1,1 @@
+alter table subject ALTER COLUMN name TYPE VARCHAR (255);

--- a/appng-core/src/main/resources/db/migration/postgresql/V4_2_1__change_subject_name_length.sql
+++ b/appng-core/src/main/resources/db/migration/postgresql/V4_2_1__change_subject_name_length.sql
@@ -1,1 +1,1 @@
-alter table subject ALTER COLUMN name TYPE VARCHAR (255);
+alter table subject alter column name set not null;

--- a/appng-core/src/test/java/org/appng/core/service/DatabaseServiceTest.java
+++ b/appng-core/src/test/java/org/appng/core/service/DatabaseServiceTest.java
@@ -71,7 +71,7 @@ public class DatabaseServiceTest extends TestInitializer {
 		String rootName = "appNG Root Database";
 		Assert.assertEquals(rootName, platformConnection.getDescription());
 		Assert.assertEquals(DatabaseType.HSQL, platformConnection.getType());
-		validateSchemaVersion(platformConnection, "4.2");
+		validateSchemaVersion(platformConnection, "4.2.1");
 
 		DatabaseConnection mssql = new DatabaseConnection(DatabaseType.MSSQL, rootName, "", "".getBytes());
 		mssql.setName(rootName);
@@ -189,7 +189,7 @@ public class DatabaseServiceTest extends TestInitializer {
 		if (checksize) {
 			Assert.assertTrue(platformConnection.getDatabaseSize() > 0.0d);
 		}
-		validateSchemaVersion(platformConnection, "4.2");
+		validateSchemaVersion(platformConnection, "4.2.1");
 
 		testRootConnectionJPA(platformConnection);
 		if (checkConnection) {

--- a/appng-core/src/test/java/org/appng/core/service/LdapContextMock.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapContextMock.java
@@ -176,7 +176,7 @@ public class LdapContextMock implements LdapContext {
 
 	@Override
 	public Attributes getAttributes(String name, String[] attrIds) throws NamingException {
-		if (name.endsWith(groupBaseDn)) {
+		if (name.endsWith(groupBaseDn) && null != attrIds) {
 			Answer<NamingEnumeration<?>> attrEnumAnswer;
 			Attributes groupAttrs = Mockito.mock(Attributes.class);
 			Attribute memberAttr = Mockito.mock(Attribute.class);

--- a/appng-core/src/test/java/org/appng/core/service/LdapServiceIT.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapServiceIT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2011-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.appng.core.service;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.naming.ldap.LdapName;
+
+import org.appng.api.model.Properties;
+import org.appng.api.model.Site;
+import org.appng.core.domain.SubjectImpl;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.ldap.core.LdapAttributes;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.ldap.ldif.parser.LdifParser;
+import org.testcontainers.containers.GenericContainer;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Ignore("run locally")
+public class LdapServiceIT {
+
+	private static final String USER_SECRET = "secret";
+	private static final String USER_DN = "uid=admin,ou=system";
+	private static GenericContainer<?> apacheDS;
+	private static int mappedPort;
+
+	@BeforeClass
+	public static void setup() throws Exception {
+		apacheDS = new GenericContainer<>("greggigon/apacheds");
+		apacheDS.withExposedPorts(10389);
+		apacheDS.start();
+		mappedPort = apacheDS.getMappedPort(10389);
+		LOGGER.info("ApacheDS running on port {}", mappedPort);
+		writeUsersAndGroups();
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		apacheDS.stop();
+		apacheDS.close();
+	}
+
+	@Test
+	public void testLoginGroup() throws Exception {
+		Site site = mockSite("dc=example,dc=com");
+		List<String> groups = Arrays.asList("SHIELD", "Heroes", "Looney Tunes");
+		new LdapService().loginGroup(site, "John Wick", "secret".toCharArray(), new SubjectImpl(), groups);
+	}
+
+	@Test
+	public void testGetMembersOfGroup() throws Exception {
+		Site site = mockSite("dc=example,dc=com");
+		List<SubjectImpl> membersOfGroup = new LdapService().getMembersOfGroup(site, "Looney Tunes");
+		Assert.assertEquals(3, membersOfGroup.size());
+		Assert.assertEquals("jane@example.com", membersOfGroup.get(0).getEmail());
+		Assert.assertEquals("joe@example.com", membersOfGroup.get(1).getEmail());
+		Assert.assertEquals("john@example.com", membersOfGroup.get(2).getEmail());
+	}
+
+	private Site mockSite(String groupBaseDn) {
+		Site site = Mockito.mock(Site.class);
+		Properties siteProps = Mockito.mock(Properties.class);
+		Mockito.when(site.getProperties()).thenReturn(siteProps);
+
+		Mockito.when(siteProps.getString(LdapService.LDAP_HOST)).thenReturn("ldap://localhost:" + mappedPort);
+		Mockito.when(siteProps.getString(LdapService.LDAP_ID_ATTRIBUTE)).thenReturn("cn");
+		Mockito.when(siteProps.getString(LdapService.LDAP_USER)).thenReturn(USER_DN);
+		Mockito.when(siteProps.getString(LdapService.LDAP_PASSWORD)).thenReturn(USER_SECRET);
+		Mockito.when(siteProps.getString(LdapService.LDAP_GROUP_BASE_DN)).thenReturn(groupBaseDn);
+		Mockito.when(siteProps.getString(LdapService.LDAP_USER_BASE_DN)).thenReturn("ou=Users,dc=example,dc=com");
+		Mockito.when(siteProps.getString(LdapService.LDAP_PRINCIPAL_SCHEME)).thenReturn("DN");
+		Mockito.when(siteProps.getBoolean(LdapService.LDAP_START_TLS)).thenReturn(false);
+		return site;
+	}
+
+	private static void writeUsersAndGroups() throws Exception, IOException {
+		LdapContextSource contextSource = new LdapContextSource();
+		contextSource.setUserDn(USER_DN);
+		contextSource.setPassword(USER_SECRET);
+		contextSource.setUrl("ldap://localhost:" + mappedPort);
+		contextSource.afterPropertiesSet();
+		LdapTemplate ldapTemplate = new LdapTemplate(contextSource);
+		LdifParser parser = new LdifParser(new ClassPathResource("ldif/users-and-groups.ldif"));
+		parser.open();
+		while (parser.hasMoreRecords()) {
+			LdapAttributes record = parser.getRecord();
+			LdapName dn = record.getName();
+			ldapTemplate.bind(dn, null, record);
+			LOGGER.info("Wrote: {}", dn);
+		}
+		parser.close();
+	}
+
+}

--- a/appng-core/src/test/java/org/appng/core/service/LdapServiceTest.java
+++ b/appng-core/src/test/java/org/appng/core/service/LdapServiceTest.java
@@ -164,6 +164,24 @@ public class LdapServiceTest {
 	}
 
 	@Test
+	public void testLoginGroupExistentNoGroupBaseDn() throws NamingException, IOException {
+		List<String> searchedGroups;
+		List<String> resultGroups;
+
+		sitePropertyMocks.replace(LdapService.LDAP_PRINCIPAL_SCHEME, "UPN");
+		sitePropertyMocks.replace(LdapService.LDAP_DOMAIN, "egypt");
+		sitePropertyMocks.put(LdapService.LDAP_USER, "mondoshawan");
+		sitePropertyMocks.put(LdapService.LDAP_PASSWORD, "stones");
+		sitePropertyMocks.put(LdapService.LDAP_USER_BASE_DN, "ou=users,l=egypt");
+		sitePropertyMocks.put(LdapService.LDAP_GROUP_BASE_DN, "");
+
+		setup("aziz@egypt", "light", "mondoshawan@egypt", "stones");
+		searchedGroups = Arrays.asList("cn=logingroup,ou=groups,l=egypt");
+		resultGroups = ldapService.loginGroup(mockedSite, "aZiZ", "light".toCharArray(), mockedSubject, searchedGroups);
+		Assert.assertArrayEquals(searchedGroups.toArray(new String[0]), resultGroups.toArray(new String[0]));
+	}
+
+	@Test
 	// The same as testLoginGroupExistent(), but additionally tests, if service user logins with DN do work.
 	public void testLoginGroupExistentServiceUserDirectDN() throws NamingException, IOException {
 		List<String> searchedGroups;

--- a/appng-core/src/test/resources/ldif/users-and-groups.ldif
+++ b/appng-core/src/test/resources/ldif/users-and-groups.ldif
@@ -1,0 +1,84 @@
+dn: ou=Users,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Users
+
+dn: ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: ou=Marvel,ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Marvel
+
+dn: ou=DC,ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: DC
+
+dn: ou=ACME,ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: ACME
+
+dn: cn=Joe Bloggs,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Joe Bloggs
+sn: Bloggs
+ou: Author
+givenName: Joe
+mail: joe@example.com
+uid: jbloggs
+userPassword:: c2VjcmV0
+
+dn: cn=Jane Doe,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Jane Doe
+sn: Doe
+ou: Admin
+givenName: Jane
+mail: jane@example.com
+uid: jdoe
+userPassword:: c2VjcmV0
+
+dn: cn=John Wick,ou=Users,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: John Wick
+sn: Wick
+ou: Reviewer
+givenName: John
+mail: john@example.com
+uid: jwick
+userPassword:: c2VjcmV0
+
+dn: cn=SHIELD,ou=Marvel,ou=Groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: SHIELD
+member: cn=John Wick,ou=Users,dc=example,dc=com
+
+dn: cn=Heroes,ou=DC,ou=Groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: Heroes
+member: cn=Jane Doe,ou=Users,dc=example,dc=com
+member: cn=John Wick,ou=Users,dc=example,dc=com
+
+dn: cn=Looney Tunes,ou=ACME,ou=Groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: Looney Tunes
+member: cn=Jane Doe,ou=Users,dc=example,dc=com
+member: cn=Joe Bloggs,ou=Users,dc=example,dc=com
+member: cn=John Wick,ou=Users,dc=example,dc=com


### PR DESCRIPTION
This feature enables, that LDAP groups can be in different organizational units in LDAP. Now it is possible to either define a common groupBaseDn for all groups or to leave the property emptry and add the full LDAP name in the name of the group 